### PR TITLE
Fix stable chart

### DIFF
--- a/hack/chart/voyager/Chart.yaml
+++ b/hack/chart/voyager/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 description: Voyager provides controller for Ingress and Certificates for Kubernetes developed by AppsCode.
+icon: https://cdn.appscode.com/images/icon/voyager.png
 name: voyager
 version: 0.1.0
 sources:
   - https://github.com/appscode/voyager
 maintainers:
-  - name: appscode
+  - name: 'AppsCode Inc.'
     email: support@appscode.com

--- a/hack/chart/voyager/README.md
+++ b/hack/chart/voyager/README.md
@@ -39,8 +39,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following tables lists the configurable parameters of the Voyager chart and their default values.
 
 
-| Parameter                  | Description                                | Default                                                    |
-| -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
+| Parameter                  | Description                  | Default              |
+| -----------------------    | ---------------------------- | -------------------- |
 | `image`                    |  Container image to run      | `appscode/voyager`   |
-| `imagePullPolicy`          |  Image pull policy           | `Always`   |
-| `imageTag`                 |  Image tag of contianer      | `1.5.0`   |
+| `imageTag`                 |  Image tag of container      | `1.5.1`              |

--- a/hack/chart/voyager/templates/NOTES.txt
+++ b/hack/chart/voyager/templates/NOTES.txt
@@ -1,3 +1,5 @@
+Set cloudProvider, clustername for installing voyager
+
 To verify that voyager controller has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get deployments -l "release={{ .Release.Name }}, run={{ template "fullname" . }}"

--- a/hack/chart/voyager/templates/_helpers.tpl
+++ b/hack/chart/voyager/templates/_helpers.tpl
@@ -12,5 +12,5 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" $name .Release.Name | trunc 45 -}}
 {{- end -}}

--- a/hack/chart/voyager/templates/deployment.yaml
+++ b/hack/chart/voyager/templates/deployment.yaml
@@ -22,5 +22,4 @@ spec:
         - --cloud-provider={{.Values.cloudProvider}}
         - --cluster-name={{.Values.clustername}}
         image: "{{.Values.image}}:{{.Values.imageTag}}"
-        imagePullPolicy: "{{.Values.imagePullPolicy}}"
         name: {{ template "name" . }}

--- a/hack/chart/voyager/values.yaml
+++ b/hack/chart/voyager/values.yaml
@@ -2,9 +2,8 @@
 ## Voyager chart configuration
 ##
 image: appscode/voyager
-imagePullPolicy: Always
-imageTag: 1.5.0
+imageTag: 1.5.1
 ## Use cloud provider here. Read details https://github.com/appscode/voyager/blob/master/docs/user-guide/README.md
-cloudProvider: "gce"
+cloudProvider: cloud_provider
 ## Use cluster name here. Read details https://github.com/appscode/voyager/blob/master/docs/user-guide/README.md
-clustername: "appscode-cluster"
+clustername: cluster_name


### PR DESCRIPTION
```
NAME:   brazil
LAST DEPLOYED: Fri Apr 21 18:01:55 2017
NAMESPACE: sauman
STATUS: DEPLOYED

RESOURCES:
==> extensions/v1beta1/Deployment
NAME            DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
voyager-brazil  1        1        1           1          6s


NOTES:
Set cloudProvider, clustername for installing voyager

To verify that voyager controller has started, run:

  kubectl --namespace=sauman get deployments -l "release=brazil, run=voyager-brazil"
```