### PR TITLE
Do not restart lb pod when backend pod restarts

### DIFF
--- a/pkg/controller/ingress/resource.go
+++ b/pkg/controller/ingress/resource.go
@@ -6,10 +6,10 @@ import (
 )
 
 func (lbc *EngressController) IsExists() bool {
+	lbc.parse()
 	log.Infoln("Checking Ingress existence", lbc.Config.ObjectMeta)
-	var err error
 	if lbc.Options.LBType == LBDaemon {
-		_, err = lbc.KubeClient.Extensions().DaemonSets(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+		_, err := lbc.KubeClient.Extensions().DaemonSets(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
 		if k8error.IsNotFound(err) {
 			return false
 		}
@@ -20,7 +20,7 @@ func (lbc *EngressController) IsExists() bool {
 		}
 	}
 
-	_, err = lbc.KubeClient.Core().Services(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+	_, err := lbc.KubeClient.Core().Services(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
 	if k8error.IsNotFound(err) {
 		return false
 	}

--- a/test/e2e/ingress_testsuit.go
+++ b/test/e2e/ingress_testsuit.go
@@ -49,7 +49,7 @@ func (i *IngressTestSuit) setUp() error {
 		ep, err := i.t.KubeClient.Core().Endpoints(testServerSvc.Namespace).Get(testServerSvc.Name)
 		if err == nil {
 			if len(ep.Subsets) > 0 {
-				if len(ep.Subsets[0].Addresses) == 1 {
+				if len(ep.Subsets[0].Addresses) > 0 {
 					break
 				}
 			}

--- a/test/e2e/test_ingress_values.go
+++ b/test/e2e/test_ingress_values.go
@@ -68,7 +68,7 @@ var testServerRc = &api.ReplicationController{
 		},
 	},
 	Spec: api.ReplicationControllerSpec{
-		Replicas: 1,
+		Replicas: 2,
 		Selector: map[string]string{
 			"app": "test-server",
 		},


### PR DESCRIPTION
Do not restart lb pod when backend pod restarts, Fixes #69

```
mysql-user-0                           2/2       Running   0          29s
mysql-user-1                           2/2       Running   0          4m
voyager-mysql-user-ingress-s3p3f       1/1       Running   0          4m
```