### PR TITLE
Introduce NodePort mode

### DIFF
--- a/pkg/controller/ingress/create.go
+++ b/pkg/controller/ingress/create.go
@@ -96,7 +96,7 @@ func (lbc *EngressController) createLB() error {
 		}
 	} else {
 		if lbc.Options.SupportsLoadBalancerType() {
-			err := lbc.deleteRCPods()
+			err := lbc.deleteResidualPods()
 			if err != nil {
 				return errors.FromErr(err).Err()
 			}

--- a/pkg/controller/ingress/delete.go
+++ b/pkg/controller/ingress/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/appscode/errors"
 	"github.com/appscode/log"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kerr "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/selection"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -29,46 +30,58 @@ func (lbc *EngressController) Delete() error {
 }
 
 func (lbc *EngressController) deleteLB() error {
-	var err error
 	if lbc.Options.LBType == LBDaemon || lbc.Options.LBType == LBHostPort {
-		err = lbc.deleteHostPortPods()
+		err := lbc.deleteHostPortPods()
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
+	} else if lbc.Options.LBType == LBNodePort {
+		err := lbc.deleteNodePortPods()
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
 	} else {
-		err = lbc.deleteLoadBalancerPods()
+		err := lbc.deleteRCPods()
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
+		err = lbc.deleteNodePortPods()
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
 	}
-	if err != nil {
-		return errors.FromErr(err).Err()
-	}
+
 	svc, err := lbc.KubeClient.Core().Services(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
-	if err != nil {
-		return errors.FromErr(err).Err()
-	}
+	if err == nil {
+		// delete service
+		err = lbc.KubeClient.Core().Services(lbc.Config.Namespace).Delete(VoyagerPrefix+lbc.Config.Name, &kapi.DeleteOptions{})
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
 
-	// delete service
-	err = lbc.KubeClient.Core().Services(lbc.Config.Namespace).Delete(VoyagerPrefix+lbc.Config.Name, &kapi.DeleteOptions{})
-	if err != nil {
-		return errors.FromErr(err).Err()
-	}
-
-	if (lbc.Options.LBType == LBDaemon || lbc.Options.LBType == LBHostPort) && lbc.CloudManager != nil {
-		if fw, ok := lbc.CloudManager.Firewall(); ok {
-			convertedSvc := &kapi.Service{}
-			kapi.Scheme.Convert(svc, convertedSvc, nil)
-			err = fw.EnsureFirewallDeleted(convertedSvc)
-			if err != nil {
-				return errors.FromErr(err).Err()
+		if (lbc.Options.LBType == LBDaemon || lbc.Options.LBType == LBHostPort) && lbc.CloudManager != nil {
+			if fw, ok := lbc.CloudManager.Firewall(); ok {
+				convertedSvc := &kapi.Service{}
+				kapi.Scheme.Convert(svc, convertedSvc, nil)
+				err = fw.EnsureFirewallDeleted(convertedSvc)
+				if err != nil {
+					return errors.FromErr(err).Err()
+				}
 			}
 		}
-	}
 
-	if svc.Spec.Type == kapi.ServiceTypeNodePort && lbc.CloudManager != nil {
-		if lb, ok := lbc.CloudManager.LoadBalancer(); ok {
-			convertedSvc := &kapi.Service{}
-			kapi.Scheme.Convert(svc, convertedSvc, nil)
-			err = lb.EnsureLoadBalancerDeleted(lbc.Options.ClusterName, convertedSvc)
-			if err != nil {
-				return errors.FromErr(err).Err()
+		if svc.Spec.Type == kapi.ServiceTypeNodePort && lbc.CloudManager != nil {
+			if lb, ok := lbc.CloudManager.LoadBalancer(); ok {
+				convertedSvc := &kapi.Service{}
+				kapi.Scheme.Convert(svc, convertedSvc, nil)
+				err = lb.EnsureLoadBalancerDeleted(lbc.Options.ClusterName, convertedSvc)
+				if err != nil {
+					return errors.FromErr(err).Err()
+				}
 			}
 		}
+	} else if !kerr.IsNotFound(err) {
+		return errors.FromErr(err).Err()
 	}
 	return nil
 }
@@ -108,7 +121,33 @@ func (lbc *EngressController) deleteHostPortPods() error {
 	return nil
 }
 
-func (lbc *EngressController) deleteLoadBalancerPods() error {
+func (lbc *EngressController) deleteNodePortPods() error {
+	d, err := lbc.KubeClient.Extensions().Deployments(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+	// resize the controller to zero (effectively deleting all pods) before deleting it.
+	d.Spec.Replicas = 0
+	_, err = lbc.KubeClient.Extensions().Deployments(lbc.Config.Namespace).Update(d)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+
+	log.Debugln("Waiting before delete the RC")
+	time.Sleep(time.Second * 10)
+	// if update failed still trying to delete the controller.
+	falseVar := false
+	err = lbc.KubeClient.Extensions().Deployments(lbc.Config.Namespace).Delete(VoyagerPrefix+lbc.Config.Name, &kapi.DeleteOptions{
+		OrphanDependents: &falseVar,
+	})
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+	return nil
+}
+
+// Deprecated, creating pods using RC is now deprecated.
+func (lbc *EngressController) deleteRCPods() error {
 	rc, err := lbc.KubeClient.Core().ReplicationControllers(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
 	if err != nil {
 		return errors.FromErr(err).Err()

--- a/pkg/controller/ingress/delete.go
+++ b/pkg/controller/ingress/delete.go
@@ -41,7 +41,7 @@ func (lbc *EngressController) deleteLB() error {
 			return errors.FromErr(err).Err()
 		}
 	} else {
-		err := lbc.deleteRCPods()
+		err := lbc.deleteResidualPods()
 		if err != nil {
 			return errors.FromErr(err).Err()
 		}
@@ -147,7 +147,7 @@ func (lbc *EngressController) deleteNodePortPods() error {
 }
 
 // Deprecated, creating pods using RC is now deprecated.
-func (lbc *EngressController) deleteRCPods() error {
+func (lbc *EngressController) deleteResidualPods() error {
 	rc, err := lbc.KubeClient.Core().ReplicationControllers(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
 	if err != nil {
 		return errors.FromErr(err).Err()

--- a/pkg/controller/ingress/parser.go
+++ b/pkg/controller/ingress/parser.go
@@ -300,6 +300,7 @@ func (lbc *EngressController) parseOptions() {
 	}
 
 	lbc.Options.LBType = opts.LBType()
+	lbc.Options.Replicas = opts.Replicas()
 	lbc.Options.DaemonNodeSelector = ParseNodeSelector(opts.DaemonNodeSelector())
 	lbc.Options.LoadBalancerIP = opts.LoadBalancerIP()
 	lbc.Options.LoadBalancerPersist = opts.LoadBalancerPersist()

--- a/pkg/controller/ingress/resource.go
+++ b/pkg/controller/ingress/resource.go
@@ -8,29 +8,25 @@ import (
 func (lbc *EngressController) IsExists() bool {
 	lbc.parse()
 	log.Infoln("Checking Ingress existence", lbc.Config.ObjectMeta)
+	name := VoyagerPrefix + lbc.Config.Name
 	if lbc.Options.LBType == LBHostPort {
-		_, err := lbc.KubeClient.Extensions().DaemonSets(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
-		if k8error.IsNotFound(err) {
-			return false
-		}
-	} else if lbc.Options.LBType == LBNodePort {
-		_, err := lbc.KubeClient.Extensions().Deployments(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+		_, err := lbc.KubeClient.Extensions().DaemonSets(lbc.Config.Namespace).Get(name)
 		if k8error.IsNotFound(err) {
 			return false
 		}
 	} else {
-		_, err := lbc.KubeClient.Core().ReplicationControllers(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+		_, err := lbc.KubeClient.Extensions().Deployments(lbc.Config.Namespace).Get(name)
 		if k8error.IsNotFound(err) {
 			return false
 		}
 	}
 
-	_, err := lbc.KubeClient.Core().Services(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+	_, err := lbc.KubeClient.Core().Services(lbc.Config.Namespace).Get(name)
 	if k8error.IsNotFound(err) {
 		return false
 	}
 
-	_, err = lbc.KubeClient.Core().ConfigMaps(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+	_, err = lbc.KubeClient.Core().ConfigMaps(lbc.Config.Namespace).Get(name)
 	if k8error.IsNotFound(err) {
 		return false
 	}

--- a/pkg/controller/ingress/resource.go
+++ b/pkg/controller/ingress/resource.go
@@ -13,6 +13,11 @@ func (lbc *EngressController) IsExists() bool {
 		if k8error.IsNotFound(err) {
 			return false
 		}
+	} else if lbc.Options.LBType == LBNodePort {
+		_, err := lbc.KubeClient.Extensions().Deployments(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
+		if k8error.IsNotFound(err) {
+			return false
+		}
 	} else {
 		_, err := lbc.KubeClient.Core().ReplicationControllers(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
 		if k8error.IsNotFound(err) {

--- a/pkg/controller/ingress/update.go
+++ b/pkg/controller/ingress/update.go
@@ -83,7 +83,7 @@ func (lbc *EngressController) recreatePods() error {
 		}
 	} else {
 		if lbc.Options.SupportsLoadBalancerType() {
-			err := lbc.deleteRCPods()
+			err := lbc.deleteResidualPods()
 			if err != nil {
 				return errors.FromErr(err).Err()
 			}

--- a/pkg/controller/ingress/update.go
+++ b/pkg/controller/ingress/update.go
@@ -72,13 +72,26 @@ func (lbc *EngressController) recreatePods() error {
 		if err != nil {
 			return errors.FromErr(err).Err()
 		}
+	} else if lbc.Options.LBType == LBNodePort {
+		err := lbc.deleteNodePortPods()
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
+		err = lbc.createNodePortPods()
+		if err != nil {
+			return errors.FromErr(err).Err()
+		}
 	} else {
 		if lbc.Options.SupportsLoadBalancerType() {
-			err := lbc.deleteLoadBalancerPods()
+			err := lbc.deleteRCPods()
 			if err != nil {
 				return errors.FromErr(err).Err()
 			}
-			err = lbc.createLoadBalancerPods()
+			err = lbc.deleteNodePortPods()
+			if err != nil {
+				return errors.FromErr(err).Err()
+			}
+			err = lbc.createNodePortPods()
 			if err != nil {
 				return errors.FromErr(err).Err()
 			}


### PR DESCRIPTION
- NodePort mode: In `NodePort` mode, a `NodePort` service will be used to expose HAProxy. No Firewall in configured. Fixes #68 
- Adds `ingress.appscode.com/replicas` annotation so users can set # of replicas for HAProxy pods.
- Renamed `ingress.appscode.com/loadbalancer.persist` to `ingress.appscode.com/persist`.
- Use Deployment to create HAProxy pods instead of RC. This is important, since replicas > 1