### PR TITLE
Always enable proxy protocol for AWS loadbalancers

### DIFF
--- a/pkg/controller/ingress/create.go
+++ b/pkg/controller/ingress/create.go
@@ -379,6 +379,10 @@ func (lbc *EngressController) createLoadBalancerSvc() error {
 			Selector: labelsFor(lbc.Config.Name),
 		},
 	}
+	if lbc.Options.ProviderName == "aws" {
+		// ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"] = "*"
+	}
 
 	// opening other tcp ports
 	for _, port := range lbc.Options.Ports {


### PR DESCRIPTION
Fixes #100 

cc: @julianvmodesto 