### PR TITLE
Improve test framework

### DIFF
--- a/pkg/controller/ingress/create.go
+++ b/pkg/controller/ingress/create.go
@@ -74,7 +74,7 @@ func (lbc *EngressController) createConfigMap() error {
 }
 
 func (lbc *EngressController) createLB() error {
-	if lbc.Options.LBType == LBDaemon || lbc.Options.LBType == LBHostPort {
+	if lbc.Options.LBType == LBTypeDaemon || lbc.Options.LBType == LBTypeHostPort {
 		err := lbc.createHostPortPods()
 		if err != nil {
 			return errors.FromErr(err).Err()
@@ -84,7 +84,7 @@ func (lbc *EngressController) createLB() error {
 		if err != nil {
 			return errors.FromErr(err).Err()
 		}
-	} else if lbc.Options.LBType == LBNodePort {
+	} else if lbc.Options.LBType == LBTypeNodePort {
 		err := lbc.createNodePortPods()
 		if err != nil {
 			return errors.FromErr(err).Err()
@@ -124,7 +124,7 @@ func (lbc *EngressController) createHostPortSvc() error {
 			Namespace: lbc.Config.Namespace,
 			Annotations: map[string]string{
 				LBName: lbc.Config.GetName(),
-				LBType: LBHostPort,
+				LBType: LBTypeHostPort,
 			},
 		},
 
@@ -275,7 +275,7 @@ func (lbc *EngressController) createNodePortSvc() error {
 			Namespace: lbc.Config.Namespace,
 			Annotations: map[string]string{
 				LBName: lbc.Config.GetName(),
-				LBType: LBNodePort,
+				LBType: LBTypeNodePort,
 			},
 		},
 		Spec: kapi.ServiceSpec{
@@ -393,7 +393,7 @@ func (lbc *EngressController) createLoadBalancerSvc() error {
 			Namespace: lbc.Config.Namespace,
 			Annotations: map[string]string{
 				LBName: lbc.Config.GetName(),
-				LBType: LBLoadBalancer,
+				LBType: LBTypeLoadBalancer,
 			},
 		},
 		Spec: kapi.ServiceSpec{

--- a/pkg/controller/ingress/delete.go
+++ b/pkg/controller/ingress/delete.go
@@ -30,12 +30,12 @@ func (lbc *EngressController) Delete() error {
 }
 
 func (lbc *EngressController) deleteLB() error {
-	if lbc.Options.LBType == LBDaemon || lbc.Options.LBType == LBHostPort {
+	if lbc.Options.LBType == LBTypeDaemon || lbc.Options.LBType == LBTypeHostPort {
 		err := lbc.deleteHostPortPods()
 		if err != nil {
 			return errors.FromErr(err).Err()
 		}
-	} else if lbc.Options.LBType == LBNodePort {
+	} else if lbc.Options.LBType == LBTypeNodePort {
 		err := lbc.deleteNodePortPods()
 		if err != nil {
 			return errors.FromErr(err).Err()
@@ -57,7 +57,7 @@ func (lbc *EngressController) deleteLB() error {
 			return errors.FromErr(err).Err()
 		}
 
-		if (lbc.Options.LBType == LBDaemon || lbc.Options.LBType == LBHostPort) && lbc.CloudManager != nil {
+		if (lbc.Options.LBType == LBTypeDaemon || lbc.Options.LBType == LBTypeHostPort) && lbc.CloudManager != nil {
 			if fw, ok := lbc.CloudManager.Firewall(); ok {
 				convertedSvc := &kapi.Service{}
 				kapi.Scheme.Convert(svc, convertedSvc, nil)

--- a/pkg/controller/ingress/resource.go
+++ b/pkg/controller/ingress/resource.go
@@ -9,7 +9,7 @@ func (lbc *EngressController) IsExists() bool {
 	lbc.parse()
 	log.Infoln("Checking Ingress existence", lbc.Config.ObjectMeta)
 	name := VoyagerPrefix + lbc.Config.Name
-	if lbc.Options.LBType == LBHostPort {
+	if lbc.Options.LBType == LBTypeHostPort {
 		_, err := lbc.KubeClient.Extensions().DaemonSets(lbc.Config.Namespace).Get(name)
 		if k8error.IsNotFound(err) {
 			return false

--- a/pkg/controller/ingress/resource_test.go
+++ b/pkg/controller/ingress/resource_test.go
@@ -19,7 +19,7 @@ func TestResourceIsExists(t *testing.T) {
 	testCases := map[*EngressController]bool{
 		{
 			Options: &KubeOptions{
-				LBType: LBHostPort,
+				LBType: LBTypeHostPort,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{
@@ -53,7 +53,7 @@ func TestResourceIsExists(t *testing.T) {
 
 		{
 			Options: &KubeOptions{
-				LBType: LBHostPort,
+				LBType: LBTypeHostPort,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{
@@ -87,7 +87,7 @@ func TestResourceIsExists(t *testing.T) {
 
 		{
 			Options: &KubeOptions{
-				LBType: LBHostPort,
+				LBType: LBTypeHostPort,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{
@@ -121,7 +121,7 @@ func TestResourceIsExists(t *testing.T) {
 
 		{
 			Options: &KubeOptions{
-				LBType: LBHostPort,
+				LBType: LBTypeHostPort,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{
@@ -155,7 +155,7 @@ func TestResourceIsExists(t *testing.T) {
 
 		{
 			Options: &KubeOptions{
-				LBType: LBHostPort,
+				LBType: LBTypeHostPort,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{
@@ -189,7 +189,7 @@ func TestResourceIsExists(t *testing.T) {
 
 		{
 			Options: &KubeOptions{
-				LBType: LBLoadBalancer,
+				LBType: LBTypeLoadBalancer,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{
@@ -223,7 +223,7 @@ func TestResourceIsExists(t *testing.T) {
 
 		{
 			Options: &KubeOptions{
-				LBType: LBLoadBalancer,
+				LBType: LBTypeLoadBalancer,
 			},
 			Config: &aci.Ingress{
 				ObjectMeta: api.ObjectMeta{

--- a/pkg/controller/ingress/types.go
+++ b/pkg/controller/ingress/types.go
@@ -32,11 +32,11 @@ const (
 	// Daemon, Persistent, LoadBalancer
 	LBType = AnnotationPrefix + "type"
 
-	LBNodePort = "NodePort"
-	LBHostPort = "HostPort"
-	// Deprecated, use LBHostPort
-	LBDaemon       = "Daemon"
-	LBLoadBalancer = "LoadBalancer" // default
+	LBTypeNodePort = "NodePort"
+	LBTypeHostPort = "HostPort"
+	// Deprecated, use LBTypeHostPort
+	LBTypeDaemon       = "Daemon"
+	LBTypeLoadBalancer = "LoadBalancer" // default
 
 	// Runs on a specific set of a hosts via DaemonSet. This is needed to work around the issue that master node is registered but not scheduable.
 	DaemonNodeSelector = AnnotationPrefix + "daemon.nodeSelector"
@@ -87,7 +87,7 @@ func (s annotation) LBType() string {
 	if v, ok := s[LBType]; ok {
 		return v
 	}
-	return LBLoadBalancer
+	return LBTypeLoadBalancer
 }
 
 func (s annotation) Replicas() int32 {

--- a/test/e2e/ingress_testsuit.go
+++ b/test/e2e/ingress_testsuit.go
@@ -9,7 +9,13 @@ import (
 	"github.com/appscode/log"
 	"k8s.io/kubernetes/pkg/api"
 	k8serr "k8s.io/kubernetes/pkg/api/errors"
+	"sync"
+	"runtime"
 )
+
+func init()  {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+}
 
 type IngressTestSuit struct {
 	t TestSuit
@@ -64,12 +70,15 @@ func (i *IngressTestSuit) setUp() error {
 
 func (i *IngressTestSuit) cleanUp() {
 	if i.t.Config.Cleanup {
-		i.t.KubeClient.Core().Services(testServerSvc.Namespace).Delete(testServerRc.Name, &api.DeleteOptions{
-			OrphanDependents: &i.t.Config.Cleanup,
-		})
-		i.t.KubeClient.Core().ReplicationControllers(testServerSvc.Namespace).Delete(testServerSvc.Name, &api.DeleteOptions{
-			OrphanDependents: &i.t.Config.Cleanup,
-		})
+		log.Infoln("Cleaning up Test Resources")
+		i.t.KubeClient.Core().Services(testServerSvc.Namespace).Delete(testServerSvc.Name, &api.DeleteOptions{})
+		rc, err := i.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Get(testServerRc.Name)
+		if err == nil {
+			rc.Spec.Replicas = 0
+			i.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Update(rc)
+			time.Sleep(time.Second*5)
+		}
+		i.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Delete(testServerRc.Name, &api.DeleteOptions{})
 	}
 }
 
@@ -91,20 +100,59 @@ func (i *IngressTestSuit) runTests() error {
 		}
 	}
 
+	startTime := time.Now()
+
+	errChan := make(chan error)
+	var wg sync.WaitGroup
+	limit := make(chan bool, i.t.Config.MaxConcurrentTest)
 	for _, name := range serializedMethodName {
-		log.Infoln("================== Running Test ====================", name)
 		shouldCall := ingType.MethodByName(name)
 		if shouldCall.IsValid() {
-			results := shouldCall.Call([]reflect.Value{})
-			if len(results) == 1 {
-				err, castOk := results[0].Interface().(error)
-				if castOk {
-					return err
+			limit <- true
+			wg.Add(1)
+			// Run Test in separate goroutine
+			go func (fun reflect.Value, n string) {
+				defer func() {
+					<-limit
+					log.Infoln("Test", n, "FINISHED")
+					wg.Done()
+				}()
+
+				log.Infoln("================== Running Test ====================", n)
+				results := fun.Call([]reflect.Value{})
+				if len(results) == 1 {
+					err, castOk := results[0].Interface().(error)
+					if castOk {
+						log.Infoln("Test", n, "FAILED with Cause", err)
+						errChan <- errors.FromErr(err).WithMessagef("Test Name %s", n).Err()
+					}
 				}
-			}
-			log.Infoln("Wait a bit for things to be clean up inside cluster")
-			time.Sleep(time.Second * 20)
+			}(shouldCall, name)
 		}
+	}
+
+	// ReadLoop
+	errs := make([]error, 0)
+	go func() {
+		for err := range errChan {
+			errs = append(errs, err)
+		}
+	}()
+
+	// Wait For All to Be DONE
+	wg.Wait()
+
+	log.Infoln("======================================")
+	log.Infoln("TOTAL", len(serializedMethodName))
+	log.Infoln("PASSED", len(serializedMethodName) - len(errs))
+	log.Infoln("FAILED", len(errs))
+	log.Infoln("Time Elapsed", time.Since(startTime).Minutes(), "minutes")
+	log.Infoln("======================================")
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Infoln("Log\n", err)
+		}
+		return errors.New().WithMessage("Test FAILED").Err()
 	}
 	return nil
 }

--- a/test/e2e/serialized_tests.go
+++ b/test/e2e/serialized_tests.go
@@ -1,0 +1,459 @@
+package e2e
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/appscode/errors"
+	aci "github.com/appscode/k8s-addons/api"
+	"github.com/appscode/log"
+	"github.com/appscode/voyager/pkg/controller/ingress"
+	"github.com/appscode/voyager/test/test-server/testserverclient"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"sync"
+)
+
+// DaemonSet Tests can not run more than once at a time.
+var daemonTestLock sync.Mutex
+
+func (ing *IngressTestSuit) TestIngressDaemonCreate() error {
+	daemonTestLock.Lock()
+	defer daemonTestLock.Unlock()
+
+	if !ing.t.Config.InCluster && ing.t.Config.ProviderName != "minikube" {
+		log.Infoln("Test is Running from outside of cluster skipping test")
+		return nil
+	}
+
+	var nodeSelector = func() string {
+		if ing.t.Config.ProviderName == "minikube" {
+			return "kubernetes.io/hostname=minikube"
+		} else {
+			if len(ing.t.Config.DaemonHostName) > 0 {
+				return "kubernetes.io/hostname=" + ing.t.Config.DaemonHostName
+			}
+			return "kubernetes.io/hostname=" + ing.t.Config.ClusterName + "-master"
+		}
+		return ""
+	}
+
+	baseDaemonIngress := &aci.Ingress{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testIngressName(),
+			Namespace: ing.t.Config.TestNamespace,
+			Annotations: map[string]string{
+				ingress.LBType:             ingress.LBTypeHostPort,
+				ingress.DaemonNodeSelector: nodeSelector(),
+			},
+		},
+		Spec: aci.ExtendedIngressSpec{
+			Rules: []aci.ExtendedIngressRule{
+				{
+					ExtendedIngressRuleValue: aci.ExtendedIngressRuleValue{
+						HTTP: &aci.HTTPExtendedIngressRuleValue{
+							Paths: []aci.HTTPExtendedIngressPath{
+								{
+									Path: "/testpath",
+									Backend: aci.ExtendedIngressBackend{
+										ServiceName: testServerSvc.Name,
+										ServicePort: intstr.FromInt(80),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ing.t.ExtensionClient.Ingress(baseDaemonIngress.Namespace).Create(baseDaemonIngress)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if ing.t.Config.Cleanup {
+			ing.t.ExtensionClient.Ingress(baseDaemonIngress.Namespace).Delete(baseDaemonIngress.Name)
+		}
+	}()
+
+	// Wait sometime to loadbalancer be opened up.
+	time.Sleep(time.Second * 30)
+	for i := 0; i < maxRetries; i++ {
+		_, err := ing.t.KubeClient.Core().Services(baseDaemonIngress.Namespace).Get(ingress.VoyagerPrefix + baseDaemonIngress.Name)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second * 5)
+		log.Infoln("Waiting for service to be created")
+	}
+	if err != nil {
+		return errors.New().WithCause(err).Err()
+	}
+
+	serverAddr, err := ing.getDaemonURLs(baseDaemonIngress)
+	if err != nil {
+		return err
+	}
+	time.Sleep(time.Second * 20)
+	log.Infoln("Loadbalancer created, calling http endpoints for test, Total url found", len(serverAddr))
+	for _, url := range serverAddr {
+		resp, err := testserverclient.NewTestHTTPClient(url).Method("GET").Path("/testpath/ok").DoWithRetry(50)
+		if err != nil {
+			return errors.New().WithCause(err).WithMessage("Failed to connect with server").Err()
+		}
+		log.Infoln("Response", *resp)
+		if resp.Method != http.MethodGet {
+			return errors.New().WithMessage("Method did not matched").Err()
+		}
+
+		if resp.Path != "/testpath/ok" {
+			return errors.New().WithMessage("Path did not matched").Err()
+		}
+	}
+	return nil
+}
+
+func (ing *IngressTestSuit) TestIngressDaemonUpdate() error {
+	daemonTestLock.Lock()
+	defer daemonTestLock.Unlock()
+
+	if !ing.t.Config.InCluster && ing.t.Config.ProviderName != "minikube" {
+		log.Infoln("Test is Running from outside of cluster skipping test")
+		return nil
+	}
+
+	var nodeSelector = func() string {
+		if ing.t.Config.ProviderName == "minikube" {
+			return "kubernetes.io/hostname=minikube"
+		} else {
+			if len(ing.t.Config.DaemonHostName) > 0 {
+				return "kubernetes.io/hostname=" + ing.t.Config.DaemonHostName
+			}
+			return "kubernetes.io/hostname=" + ing.t.Config.ClusterName + "-master"
+		}
+		return ""
+	}
+	baseIngress := &aci.Ingress{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testIngressName(),
+			Namespace: ing.t.Config.TestNamespace,
+			Annotations: map[string]string{
+				ingress.LBType:             ingress.LBTypeHostPort,
+				ingress.DaemonNodeSelector: nodeSelector(),
+			},
+		},
+		Spec: aci.ExtendedIngressSpec{
+			Rules: []aci.ExtendedIngressRule{
+				{
+					ExtendedIngressRuleValue: aci.ExtendedIngressRuleValue{
+						HTTP: &aci.HTTPExtendedIngressRuleValue{
+							Paths: []aci.HTTPExtendedIngressPath{
+								{
+									Path: "/testpath",
+									Backend: aci.ExtendedIngressBackend{
+										ServiceName: testServerSvc.Name,
+										ServicePort: intstr.FromInt(80),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ing.t.ExtensionClient.Ingress(baseIngress.Namespace).Create(baseIngress)
+	if err != nil {
+		return errors.New().WithCause(err).Err()
+	}
+	defer func() {
+		if ing.t.Config.Cleanup {
+			ing.t.ExtensionClient.Ingress(baseIngress.Namespace).Delete(baseIngress.Name)
+		}
+	}()
+
+	// Wait sometime to loadbalancer be opened up.
+	time.Sleep(time.Second * 10)
+	for i := 0; i < maxRetries; i++ {
+		_, err := ing.t.KubeClient.Core().Services(baseIngress.Namespace).Get(ingress.VoyagerPrefix + baseIngress.Name)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second * 5)
+		log.Infoln("Waiting for service to be created")
+	}
+	if err != nil {
+		return err
+	}
+
+	serverAddr, err := ing.getDaemonURLs(baseIngress)
+	if err != nil {
+		return err
+	}
+	time.Sleep(time.Second * 20)
+	log.Infoln("Loadbalancer created, calling http endpoints, Total", len(serverAddr))
+	for _, url := range serverAddr {
+		resp, err := testserverclient.NewTestHTTPClient(url).Method("GET").Path("/testpath/ok").DoWithRetry(50)
+		if err != nil {
+			return errors.New().WithCause(err).WithMessage("Failed to connect with server").Err()
+		}
+		log.Infoln("Response", *resp)
+		if resp.Method != http.MethodGet {
+			return errors.New().WithMessage("Method did not matched").Err()
+		}
+
+		if resp.Path != "/testpath/ok" {
+			return errors.New().WithMessage("Path did not matched").Err()
+		}
+	}
+
+	updatedBaseIngress, err := ing.t.ExtensionClient.Ingress(baseIngress.Namespace).Get(baseIngress.Name)
+	if err != nil {
+		return errors.New().WithCause(err).Err()
+	}
+	updatedBaseIngress.Spec.Rules[0].HTTP.Paths[0].Path = "/newTestpath"
+	_, err = ing.t.ExtensionClient.Ingress(baseIngress.Namespace).Update(updatedBaseIngress)
+	if err != nil {
+		return errors.New().WithCause(err).Err()
+	}
+
+	time.Sleep(time.Second * 30)
+	serverAddr, err = ing.getDaemonURLs(baseIngress)
+	if err != nil {
+		return err
+	}
+	time.Sleep(time.Second * 30)
+	log.Infoln("Loadbalancer created, calling http endpoints for updated path, Total", len(serverAddr))
+	for _, url := range serverAddr {
+		var resp *testserverclient.Response
+		notFound := false
+		for i := 0; i < maxRetries; i++ {
+			var err error
+			resp, err = testserverclient.NewTestHTTPClient(url).Method("GET").Path("/testpath/ok").DoWithRetry(1)
+			if err != nil {
+				notFound = true
+				break
+			}
+			time.Sleep(time.Second * 5)
+			log.Infoln("Expected exception, faild to connect with old path, calling new paths.")
+		}
+		if !notFound {
+			return errors.New().WithCause(err).WithMessage("Connected with old prefix").Err()
+		}
+		resp, err = testserverclient.NewTestHTTPClient(url).Method("GET").Path("/newTestpath/ok").DoWithRetry(100)
+		if err != nil {
+			return errors.New().WithCause(err).WithMessage("Failed to Connect With New Prefix").Err()
+		}
+		log.Infoln("Response", *resp)
+		if resp.Method != http.MethodGet {
+			return errors.New().WithMessage("Method did not matched").Err()
+		}
+
+		if resp.Path != "/newTestpath/ok" {
+			return errors.New().WithMessage("Path did not matched").Err()
+		}
+	}
+
+	// Open New Port
+	updatedBaseIngress, err = ing.t.ExtensionClient.Ingress(baseIngress.Namespace).Get(baseIngress.Name)
+	if err != nil {
+		return errors.New().WithCause(err).Err()
+	}
+
+	if ing.t.Config.ProviderName != "minikube" {
+		updatedBaseIngress.Spec.Rules[0].HTTP = nil
+		updatedBaseIngress.Spec.Rules[0].TCP = []aci.TCPExtendedIngressRuleValue{
+			{
+				Port: intstr.FromString("4545"),
+				Backend: aci.IngressBackend{
+					ServiceName: testServerSvc.Name,
+					ServicePort: intstr.FromString("4545"),
+				},
+			},
+		}
+		_, err = ing.t.ExtensionClient.Ingress(baseIngress.Namespace).Update(updatedBaseIngress)
+		if err != nil {
+			return errors.New().WithCause(err).Err()
+		}
+		time.Sleep(time.Second * 60)
+		found := false
+		for i := 1; i <= maxRetries; i++ {
+			svc, err := ing.t.KubeClient.Core().Services(baseIngress.Namespace).Get(ingress.VoyagerPrefix + baseIngress.Name)
+			if err != nil {
+				continue
+			}
+			log.Infoln("Got Service", svc.Name)
+			for _, port := range svc.Spec.Ports {
+				log.Infoln(port)
+				if port.Port == 4545 {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+			time.Sleep(time.Second * 5)
+		}
+
+		if !found {
+			return errors.New().WithMessage("Service not found").Err()
+		}
+
+		serverAddr, err = ing.getDaemonURLs(baseIngress)
+		if err != nil {
+			return err
+		}
+		time.Sleep(time.Second * 30)
+		log.Infoln("Loadbalancer created, calling http endpoints for updated path, Total", len(serverAddr))
+		for _, url := range serverAddr {
+			resp, err := testserverclient.NewTestTCPClient(url).DoWithRetry(50)
+			if err != nil {
+				return errors.New().WithCause(err).WithMessage("Failed to Connect With New Prefix").Err()
+			}
+			log.Infoln("Response", *resp)
+			if resp.ServerPort != ":4545" {
+				return errors.New().WithMessage("Port did not matched").Err()
+			}
+		}
+	}
+	return nil
+}
+
+func (ing *IngressTestSuit) TestIngressDaemonRestart() error {
+	daemonTestLock.Lock()
+	defer daemonTestLock.Unlock()
+
+	if !ing.t.Config.InCluster && ing.t.Config.ProviderName != "minikube" {
+		log.Infoln("Test is Running from outside of cluster skipping test")
+		return nil
+	}
+
+	var nodeSelector = func() string {
+		if ing.t.Config.ProviderName == "minikube" {
+			return "kubernetes.io/hostname=minikube"
+		} else {
+			if len(ing.t.Config.DaemonHostName) > 0 {
+				return "kubernetes.io/hostname=" + ing.t.Config.DaemonHostName
+			}
+			return "kubernetes.io/hostname=" + ing.t.Config.ClusterName + "-master"
+		}
+		return ""
+	}
+
+	baseDaemonIngress := &aci.Ingress{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testIngressName(),
+			Namespace: ing.t.Config.TestNamespace,
+			Annotations: map[string]string{
+				ingress.LBType:             ingress.LBTypeHostPort,
+				ingress.DaemonNodeSelector: nodeSelector(),
+			},
+		},
+		Spec: aci.ExtendedIngressSpec{
+			Rules: []aci.ExtendedIngressRule{
+				{
+					ExtendedIngressRuleValue: aci.ExtendedIngressRuleValue{
+						HTTP: &aci.HTTPExtendedIngressRuleValue{
+							Paths: []aci.HTTPExtendedIngressPath{
+								{
+									Path: "/testpath",
+									Backend: aci.ExtendedIngressBackend{
+										ServiceName: testServerSvc.Name,
+										ServicePort: intstr.FromInt(80),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ing.t.ExtensionClient.Ingress(baseDaemonIngress.Namespace).Create(baseDaemonIngress)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if ing.t.Config.Cleanup {
+			ing.t.ExtensionClient.Ingress(baseDaemonIngress.Namespace).Delete(baseDaemonIngress.Name)
+		}
+	}()
+
+	// Wait sometime to loadbalancer be opened up.
+	time.Sleep(time.Second * 10)
+	for i := 0; i < maxRetries; i++ {
+		_, err := ing.t.KubeClient.Core().Services(baseDaemonIngress.Namespace).Get(ingress.VoyagerPrefix + baseDaemonIngress.Name)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second * 5)
+		log.Infoln("Waiting for service to be created")
+	}
+	if err != nil {
+		return errors.New().WithCause(err).Err()
+	}
+
+	serverAddr, err := ing.getDaemonURLs(baseDaemonIngress)
+	if err != nil {
+		return err
+	}
+	time.Sleep(time.Second * 20)
+	log.Infoln("Loadbalancer created, calling http endpoints for test, Total url found", len(serverAddr))
+	for _, url := range serverAddr {
+		resp, err := testserverclient.NewTestHTTPClient(url).Method("GET").Path("/testpath/ok").DoWithRetry(50)
+		if err != nil {
+			return errors.New().WithCause(err).WithMessage("Failed to connect with server").Err()
+		}
+		log.Infoln("Response", *resp)
+		if resp.Method != http.MethodGet {
+			return errors.New().WithMessage("Method did not matched").Err()
+		}
+
+		if resp.Path != "/testpath/ok" {
+			return errors.New().WithMessage("Path did not matched").Err()
+		}
+	}
+
+	// Teardown and then again create one pod of the backend
+	// And Make sure The DS does not gets deleted.
+	_, err = ing.t.KubeClient.Extensions().DaemonSets(baseDaemonIngress.Namespace).Get(ingress.VoyagerPrefix + baseDaemonIngress.Name)
+	if err != nil {
+		return err
+	}
+	rc, err := ing.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Get(testServerRc.Name)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+	rc.Spec.Replicas += 1
+	ing.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Update(rc)
+
+	rc, err = ing.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Get(testServerRc.Name)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+	rc.Spec.Replicas -= 1
+	ing.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Update(rc)
+
+	_, err = ing.t.KubeClient.Extensions().DaemonSets(baseDaemonIngress.Namespace).Get(ingress.VoyagerPrefix + baseDaemonIngress.Name)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+
+	rc, err = ing.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Get(testServerRc.Name)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+	rc.Spec.Replicas += 1
+	ing.t.KubeClient.Core().ReplicationControllers(testServerRc.Namespace).Update(rc)
+
+	_, err = ing.t.KubeClient.Extensions().DaemonSets(baseDaemonIngress.Namespace).Get(ingress.VoyagerPrefix + baseDaemonIngress.Name)
+	if err != nil {
+		return errors.FromErr(err).Err()
+	}
+	return nil
+}

--- a/test/e2e/test_ingress_values.go
+++ b/test/e2e/test_ingress_values.go
@@ -4,12 +4,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/util/intstr"
+	"github.com/appscode/voyager/test/testframework"
 )
 
 var testServerSvc = &api.Service{
 	ObjectMeta: api.ObjectMeta{
 		Name:      "test-server",
-		Namespace: TestNamespace,
+		Namespace: testframework.TestContext.E2EConfigs.TestNamespace,
 		Labels: map[string]string{
 			"app": "test-server",
 		},
@@ -55,6 +56,7 @@ var testServerSvc = &api.Service{
 		},
 		Selector: map[string]string{
 			"app": "test-server",
+			"name": "test-rc",
 		},
 	},
 }
@@ -62,9 +64,10 @@ var testServerSvc = &api.Service{
 var testServerRc = &api.ReplicationController{
 	ObjectMeta: api.ObjectMeta{
 		Name:      "test-server",
-		Namespace: TestNamespace,
+		Namespace: testframework.TestContext.E2EConfigs.TestNamespace,
 		Labels: map[string]string{
 			"app": "test-server",
+			"name": "test-rc",
 		},
 	},
 	Spec: api.ReplicationControllerSpec{
@@ -76,6 +79,7 @@ var testServerRc = &api.ReplicationController{
 			ObjectMeta: api.ObjectMeta{
 				Labels: map[string]string{
 					"app": "test-server",
+					"name": "test-rc",
 				},
 			},
 			Spec: api.PodSpec{
@@ -129,7 +133,7 @@ var testServerRc = &api.ReplicationController{
 var testStatefulSetSvc = &api.Service{
 	ObjectMeta: api.ObjectMeta{
 		Name:      "ss-svc",
-		Namespace: TestNamespace,
+		Namespace: testframework.TestContext.E2EConfigs.TestNamespace,
 		Labels: map[string]string{
 			"app": "e2e-test",
 		},
@@ -176,6 +180,7 @@ var testStatefulSetSvc = &api.Service{
 		},
 		Selector: map[string]string{
 			"app": "e2e-test",
+			"name": "test-ss",
 		},
 	},
 }
@@ -183,9 +188,10 @@ var testStatefulSetSvc = &api.Service{
 var testServerStatefulSet = &apps.StatefulSet{
 	ObjectMeta: api.ObjectMeta{
 		Name:      "test-ss",
-		Namespace: TestNamespace,
+		Namespace: testframework.TestContext.E2EConfigs.TestNamespace,
 		Labels: map[string]string{
 			"app": "e2e-test",
+			"name": "test-ss",
 		},
 	},
 	Spec: apps.StatefulSetSpec{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -23,7 +23,14 @@ func (ing *IngressTestSuit) getURLs(baseIngress *aci.Ingress) ([]string, error) 
 		for i := 0; i < maxRetries; i++ {
 			var outputs []byte
 			log.Infoln("Running Command", "`minikube", "service", ingresscontroller.VoyagerPrefix+baseIngress.Name+" --url`")
-			outputs, err = exec.Command("/usr/local/bin/minikube", "service", ingresscontroller.VoyagerPrefix+baseIngress.Name, "--url").CombinedOutput()
+			outputs, err = exec.Command(
+				"/usr/local/bin/minikube",
+				"service",
+				ingresscontroller.VoyagerPrefix+baseIngress.Name,
+				"--url",
+				"-n",
+				baseIngress.Namespace,
+			).CombinedOutput()
 			if err == nil {
 				log.Infoln("Output\n", string(outputs))
 				for _, output := range strings.Split(string(outputs), "\n") {
@@ -153,7 +160,7 @@ func (ing *IngressTestSuit) getDaemonURLs(baseIngress *aci.Ingress) ([]string, e
 }
 
 func testIngressName() string {
-	return "test-ing-" + randString(5)
+	return "test-ings-" + randString(8)
 }
 
 var alphanums = []rune("abcdefghijklmnopqrstuvwxz0123456789")

--- a/test/testframework/test_context.go
+++ b/test/testframework/test_context.go
@@ -8,6 +8,7 @@ import (
 	logginghandler "github.com/appscode/errors/h/log"
 	"github.com/appscode/go/flags"
 	"github.com/appscode/log"
+	"strings"
 )
 
 func init() {
@@ -45,6 +46,8 @@ type E2EConfig struct {
 	DaemonHostName        string
 	LBPersistIP           string
 	RunOnly               string
+	TestNamespace         string
+	MaxConcurrentTest     int
 }
 
 var TestContext TestContextType
@@ -89,6 +92,8 @@ func registerE2EFlags() {
 	flag.StringVar(&TestContext.E2EConfigs.DaemonHostName, "daemon-host-name", "", "Daemon host name to run daemon hosts")
 	flag.StringVar(&TestContext.E2EConfigs.RunOnly, "test-only", "", "Daemon host name to run daemon hosts")
 	flag.StringVar(&TestContext.E2EConfigs.LBPersistIP, "lb-ip", "", "LB persistent IP")
+	flag.StringVar(&TestContext.E2EConfigs.TestNamespace, "namespace", "test-ing", "Run tests in this namespaces")
+	flag.IntVar(&TestContext.E2EConfigs.MaxConcurrentTest, "max-test", 5, "Max Tests to run concurrently")
 }
 
 func validate() {
@@ -102,5 +107,9 @@ func validate() {
 
 	if TestContext.E2EConfigs.ClusterName == "" {
 		log.Fatal("Cluster name required, not provided")
+	}
+
+	if !strings.HasPrefix(TestContext.E2EConfigs.TestNamespace, "test-") {
+		log.Fatal("Namespace is not a Test namespace")
 	}
 }

--- a/vendor/github.com/appscode/errors/types.go
+++ b/vendor/github.com/appscode/errors/types.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/facebookgo/stack"
-	"fmt"
 )
 
 // traceableError contains the error types that holds the errors
@@ -56,7 +55,6 @@ var defaultFormatter = func(e error) string {
 			buf.WriteString("\nCaused By:\n")
 			buf.WriteString(err.cause.Error())
 		}
-		fmt.Println(err.msg)
 		if err.trace != nil {
 			buf.WriteString("\nStack trace:\n")
 			buf.WriteString(err.trace.String())

--- a/vendor/github.com/appscode/errors/types.go
+++ b/vendor/github.com/appscode/errors/types.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/facebookgo/stack"
+	"fmt"
 )
 
 // traceableError contains the error types that holds the errors
@@ -55,6 +56,7 @@ var defaultFormatter = func(e error) string {
 			buf.WriteString("\nCaused By:\n")
 			buf.WriteString(err.cause.Error())
 		}
+		fmt.Println(err.msg)
 		if err.trace != nil {
 			buf.WriteString("\nStack trace:\n")
 			buf.WriteString(err.trace.String())


### PR DESCRIPTION
This PR significantly reduced test run time by at least **one third**. Uses concurrency.

@ashiquzzaman33 
There is now two extra flag to control test namespace and test concurrency.  

`-namespace` needs to be provided while testing. The value of the flag must needs to be prefixed with **test-**. otherwise test will not run. I suggest create a `ns` as test-timestamp provide this value as flag. and remove when test is done.

`-max-test` will control how many test will run at once concurrently. The default value is 5. If you have a High node cluster, i suggest you can increase it. 