### PR TITLE
Make nodeSelector annotation applicable for any more.

### DIFF
--- a/docs/user-guide/ingress/README.md
+++ b/docs/user-guide/ingress/README.md
@@ -94,7 +94,9 @@ ingress.appscode.com/replicas              = indicates number of replicas of HAP
 
 ingress.appscode.com/nodeSelector          = This nodeSelector will indicate which host the HAProxy is going to run. This is 
                                             a required annotation for `HostPort` type ingress. The value of this annotation should 
-                                            be formatted as `foo=bar,foo2=bar2`.
+                                            be formatted as `foo=bar,foo2=bar2`. This used to be called `ingress.appscode.com/daemon.nodeSelector`.
+                                            We recommend you use the new key going forward. Any existing ingress with previous annotation
+                                            will continue to function as expected.
 
 ingress.appscode.com/ip                    = This only applies to "gce" and "gke" cloud providers. If set, it will be
                                       assigned loadbalancer used to expose HAProxy. Usually this is set to a static IP preserve DNS configuration.

--- a/docs/user-guide/ingress/README.md
+++ b/docs/user-guide/ingress/README.md
@@ -92,11 +92,9 @@ ingress.appscode.com/type                  = indicates type of service used to e
 
 ingress.appscode.com/replicas              = indicates number of replicas of HAProxy is run. The default value is 1.
 
-ingress.appscode.com/daemon.nodeSelector   = only applicatble when lb.appscode.com/type is set to HostPort (previously called Daemon),
-                                      this nodeSelector will indicate which host the load balancer
-                                      needs to run.
-                                      The format of providing nodeSelector is -
-                                      `foo=bar,foo2=bar2`
+ingress.appscode.com/nodeSelector          = This nodeSelector will indicate which host the HAProxy is going to run. This is 
+                                            a required annotation for `HostPort` type ingress. The value of this annotation should 
+                                            be formatted as `foo=bar,foo2=bar2`.
 
 ingress.appscode.com/ip                    = This only applies to "gce" and "gke" cloud providers. If set, it will be
                                       assigned loadbalancer used to expose HAProxy. Usually this is set to a static IP preserve DNS configuration.

--- a/pkg/controller/ingress/create.go
+++ b/pkg/controller/ingress/create.go
@@ -192,7 +192,7 @@ func (lbc *EngressController) createHostPortSvc() error {
 	}
 
 	daemonNodes, err := lbc.KubeClient.Core().Nodes().List(kapi.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labels.Set(lbc.Options.DaemonNodeSelector)),
+		LabelSelector: labels.SelectorFromSet(labels.Set(lbc.Options.NodeSelector)),
 	})
 	if err != nil {
 		log.Infoln("node not found with nodeSelector, cause", err)
@@ -219,7 +219,7 @@ func (lbc *EngressController) createHostPortSvc() error {
 }
 
 func (lbc *EngressController) createHostPortPods() error {
-	log.Infoln("Creating Daemon type lb for nodeSelector = ", lbc.Options.DaemonNodeSelector)
+	log.Infoln("Creating Daemon type lb for nodeSelector = ", lbc.Options.NodeSelector)
 
 	vs := Volumes(lbc.Options)
 	vms := VolumeMounts(lbc.Options)
@@ -246,7 +246,7 @@ func (lbc *EngressController) createHostPortPods() error {
 					Labels: labelsFor(lbc.Config.Name),
 				},
 				Spec: kapi.PodSpec{
-					NodeSelector: lbc.Options.DaemonNodeSelector,
+					NodeSelector: lbc.Options.NodeSelector,
 					Containers: []kapi.Container{
 						{
 							Name:  "haproxy",
@@ -393,6 +393,7 @@ func (lbc *EngressController) createNodePortPods() error {
 				},
 
 				Spec: kapi.PodSpec{
+					NodeSelector: lbc.Options.NodeSelector,
 					Containers: []kapi.Container{
 						{
 							Name:  "haproxy",

--- a/pkg/controller/ingress/parser.go
+++ b/pkg/controller/ingress/parser.go
@@ -322,7 +322,7 @@ func (lbc *EngressController) parseOptions() {
 	lbc.Parsed.AcceptProxy = lbc.Options.annotations.AcceptProxy()
 	lbc.Options.LBType = lbc.Options.annotations.LBType()
 	lbc.Options.Replicas = lbc.Options.annotations.Replicas()
-	lbc.Options.DaemonNodeSelector = ParseNodeSelector(lbc.Options.annotations.DaemonNodeSelector())
+	lbc.Options.NodeSelector = ParseNodeSelector(lbc.Options.annotations.NodeSelector())
 	lbc.Options.LoadBalancerIP = lbc.Options.annotations.LoadBalancerIP()
 	lbc.Options.LoadBalancerPersist = lbc.Options.annotations.LoadBalancerPersist()
 	log.Infoln("Got LBType", lbc.Options.LBType)

--- a/pkg/controller/ingress/types.go
+++ b/pkg/controller/ingress/types.go
@@ -140,7 +140,10 @@ func (s annotation) Replicas() int32 {
 }
 
 func (s annotation) NodeSelector() string {
-	v, _ := s[NodeSelector]
+	if v, ok := s[NodeSelector]; ok {
+		return v
+	}
+	v, _ := s[AnnotationPrefix+"daemon.nodeSelector"]
 	return v
 }
 

--- a/pkg/controller/ingress/types.go
+++ b/pkg/controller/ingress/types.go
@@ -40,8 +40,8 @@ const (
 	LBTypeDaemon       = "Daemon"
 	LBTypeLoadBalancer = "LoadBalancer" // default
 
-	// Runs on a specific set of a hosts via DaemonSet. This is needed to work around the issue that master node is registered but not scheduable.
-	DaemonNodeSelector = AnnotationPrefix + "daemon.nodeSelector"
+	// Runs HAProxy on a specific set of a hosts.
+	NodeSelector = AnnotationPrefix + "nodeSelector"
 
 	// Replicas specify # of HAProxy pods run (default 1)
 	Replicas = AnnotationPrefix + "replicas"
@@ -139,8 +139,8 @@ func (s annotation) Replicas() int32 {
 	return 1
 }
 
-func (s annotation) DaemonNodeSelector() string {
-	v, _ := s[DaemonNodeSelector]
+func (s annotation) NodeSelector() string {
+	v, _ := s[NodeSelector]
 	return v
 }
 
@@ -235,7 +235,7 @@ type KubeOptions struct {
 
 	LBType              string
 	Replicas            int32
-	DaemonNodeSelector  map[string]string
+	NodeSelector        map[string]string
 	LoadBalancerIP      string
 	LoadBalancerPersist bool
 

--- a/pkg/controller/ingress/update.go
+++ b/pkg/controller/ingress/update.go
@@ -180,7 +180,7 @@ func (lbc *EngressController) updateLBSvc() error {
 	log.Infoln("Loadbalancer CloudManager", lbc.CloudManager, "serviceType", svc.Spec.Type)
 	if (lbc.Options.LBType == LBTypeDaemon || lbc.Options.LBType == LBTypeHostPort) && lbc.CloudManager != nil {
 		daemonNodes, err := lbc.KubeClient.Core().Nodes().List(kapi.ListOptions{
-			LabelSelector: labels.SelectorFromSet(labels.Set(lbc.Options.DaemonNodeSelector)),
+			LabelSelector: labels.SelectorFromSet(labels.Set(lbc.Options.NodeSelector)),
 		})
 		if err != nil {
 			log.Infoln("node not found with nodeSelector, cause", err)

--- a/test/e2e/serialized_tests.go
+++ b/test/e2e/serialized_tests.go
@@ -43,8 +43,8 @@ func (ing *IngressTestSuit) TestIngressDaemonCreate() error {
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LBType:             ingress.LBTypeHostPort,
-				ingress.DaemonNodeSelector: nodeSelector(),
+				ingress.LBType:       ingress.LBTypeHostPort,
+				ingress.NodeSelector: nodeSelector(),
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{
@@ -140,8 +140,8 @@ func (ing *IngressTestSuit) TestIngressDaemonUpdate() error {
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LBType:             ingress.LBTypeHostPort,
-				ingress.DaemonNodeSelector: nodeSelector(),
+				ingress.LBType:       ingress.LBTypeHostPort,
+				ingress.NodeSelector: nodeSelector(),
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{
@@ -349,8 +349,8 @@ func (ing *IngressTestSuit) TestIngressDaemonRestart() error {
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LBType:             ingress.LBTypeHostPort,
-				ingress.DaemonNodeSelector: nodeSelector(),
+				ingress.LBType:       ingress.LBTypeHostPort,
+				ingress.NodeSelector: nodeSelector(),
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -104,7 +104,7 @@ func (ing *IngressTestSuit) getDaemonURLs(baseIngress *aci.Ingress) ([]string, e
 	nodes, err := ing.t.KubeClient.Core().Nodes().List(api.ListOptions{
 		LabelSelector: labels.SelectorFromSet(
 			ingresscontroller.ParseNodeSelector(
-				baseIngress.Annotations[ingresscontroller.DaemonNodeSelector],
+				baseIngress.Annotations[ingresscontroller.NodeSelector],
 			),
 		),
 	})


### PR DESCRIPTION
BREAKING: annotation key renamed from `ingress.appscode.com/daemon.nodeSelector` to `ingress.appscode.com/daemon.nodeSelector`.