### PR TITLE
Use ingress.appscode.com/keep-source-ip: true to preserve source IP

### DIFF
--- a/pkg/controller/ingress/create.go
+++ b/pkg/controller/ingress/create.go
@@ -354,7 +354,7 @@ func (lbc *EngressController) createNodePortSvc() error {
 		}
 	}
 
-	if lbc.Options.ProviderName == "aws" && lbc.Options.annotations.KeepSource() {
+	if lbc.Options.ProviderName == "aws" && lbc.Options.annotations.KeepSourceIP() {
 		// ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"] = "*"
 	}

--- a/pkg/controller/ingress/create.go
+++ b/pkg/controller/ingress/create.go
@@ -181,7 +181,7 @@ func (lbc *EngressController) createHostPortSvc() error {
 		svc.Spec.Ports = append(svc.Spec.Ports, p)
 	}
 
-	if ans, ok := lbc.Options.annotations.ServiceAnnotations(); ok {
+	if ans, ok := lbc.Options.annotations.ServiceAnnotations(lbc.Options.ProviderName, lbc.Options.LBType); ok {
 		for k, v := range ans {
 			svc.Annotations[k] = v
 		}
@@ -348,13 +348,13 @@ func (lbc *EngressController) createNodePortSvc() error {
 		svc.Spec.Ports = append(svc.Spec.Ports, p)
 	}
 
-	if ans, ok := lbc.Options.annotations.ServiceAnnotations(); ok {
+	if ans, ok := lbc.Options.annotations.ServiceAnnotations(lbc.Options.ProviderName, lbc.Options.LBType); ok {
 		for k, v := range ans {
 			svc.Annotations[k] = v
 		}
 	}
 
-	if lbc.Options.ProviderName == "aws" && lbc.Options.annotations.AcceptProxy() {
+	if lbc.Options.ProviderName == "aws" && lbc.Options.annotations.KeepSource() {
 		// ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"] = "*"
 	}
@@ -487,15 +487,10 @@ func (lbc *EngressController) createLoadBalancerSvc() error {
 		svc.Spec.Ports = append(svc.Spec.Ports, p)
 	}
 
-	if ans, ok := lbc.Options.annotations.ServiceAnnotations(); ok {
+	if ans, ok := lbc.Options.annotations.ServiceAnnotations(lbc.Options.ProviderName, lbc.Options.LBType); ok {
 		for k, v := range ans {
 			svc.Annotations[k] = v
 		}
-	}
-
-	if lbc.Options.ProviderName == "aws" && lbc.Options.annotations.AcceptProxy() {
-		// ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"] = "*"
 	}
 
 	switch lbc.Options.ProviderName {

--- a/pkg/controller/ingress/handler.go
+++ b/pkg/controller/ingress/handler.go
@@ -439,7 +439,7 @@ func isStatsChanged(old annotation, new annotation) bool {
 func (lbc *EngressController) isKeepSourceChanged(old annotation, new annotation) bool {
 	return lbc.Options.ProviderName == "aws" &&
 		lbc.Options.LBType == LBTypeLoadBalancer &&
-		isMapKeyChanged(old, new, LoadBalancerKeepSource)
+		isMapKeyChanged(old, new, LoadBalancerKeepSourceIP)
 }
 
 func isMapKeyChanged(oldMap map[string]string, newMap map[string]string, key string) bool {

--- a/pkg/controller/ingress/handler.go
+++ b/pkg/controller/ingress/handler.go
@@ -212,7 +212,7 @@ func (lbc *EngressController) Handle(e *events.Event) error {
 		}
 
 		updateMode := updateType(0)
-		if isAcceptProxyChanged(engs[0].(*aci.Ingress).ObjectMeta.Annotations, engs[1].(*aci.Ingress).ObjectMeta.Annotations) {
+		if lbc.isKeepSourceChanged(engs[0].(*aci.Ingress).ObjectMeta.Annotations, engs[1].(*aci.Ingress).ObjectMeta.Annotations) {
 			updateMode |= UpdateConfig
 		}
 
@@ -436,8 +436,10 @@ func isStatsChanged(old annotation, new annotation) bool {
 		isMapKeyChanged(old, new, StatsSecret)
 }
 
-func isAcceptProxyChanged(old annotation, new annotation) bool {
-	return isMapKeyChanged(old, new, LoadBalancerAcceptProxy)
+func (lbc *EngressController) isKeepSourceChanged(old annotation, new annotation) bool {
+	return lbc.Options.ProviderName == "aws" &&
+		lbc.Options.LBType == LBTypeLoadBalancer &&
+		isMapKeyChanged(old, new, LoadBalancerKeepSource)
 }
 
 func isMapKeyChanged(oldMap map[string]string, newMap map[string]string, key string) bool {

--- a/pkg/controller/ingress/parser.go
+++ b/pkg/controller/ingress/parser.go
@@ -322,7 +322,7 @@ func (lbc *EngressController) parseOptions() {
 	lbc.Options.LBType = lbc.Options.annotations.LBType()
 
 	if lbc.Options.ProviderName == "aws" && lbc.Options.LBType == LBTypeLoadBalancer {
-		lbc.Parsed.AcceptProxy = lbc.Options.annotations.KeepSource()
+		lbc.Parsed.AcceptProxy = lbc.Options.annotations.KeepSourceIP()
 	}
 	lbc.Options.Replicas = lbc.Options.annotations.Replicas()
 	lbc.Options.NodeSelector = ParseNodeSelector(lbc.Options.annotations.NodeSelector())

--- a/pkg/controller/ingress/parser.go
+++ b/pkg/controller/ingress/parser.go
@@ -319,8 +319,11 @@ func (lbc *EngressController) parseOptions() {
 			}
 		}
 	}
-	lbc.Parsed.AcceptProxy = lbc.Options.annotations.AcceptProxy()
 	lbc.Options.LBType = lbc.Options.annotations.LBType()
+
+	if lbc.Options.ProviderName == "aws" && lbc.Options.LBType == LBTypeLoadBalancer {
+		lbc.Parsed.AcceptProxy = lbc.Options.annotations.KeepSource()
+	}
 	lbc.Options.Replicas = lbc.Options.annotations.Replicas()
 	lbc.Options.NodeSelector = ParseNodeSelector(lbc.Options.annotations.NodeSelector())
 	lbc.Options.LoadBalancerPersist = lbc.Options.annotations.LoadBalancerPersist()

--- a/pkg/controller/ingress/template/template.go
+++ b/pkg/controller/ingress/template/template.go
@@ -93,7 +93,7 @@ backend default-backend
 {% if HttpsService %}
 # https service
 frontend https-frontend
-    bind *:443 {% if AcceptProxy %}accept-proxy{% endif %} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/ alpn http/1.1
+    bind *:443 {% if KeepSource %}accept-proxy{% endif %} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/ alpn http/1.1
     # Mark all cookies as secure
     rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure
     # Add the HSTS header with a 6 month max-age
@@ -137,7 +137,7 @@ backend https-{{ svc.Name }}
 {% if HttpService %}
 # http services.
 frontend http-frontend
-    bind *:80 {% if AcceptProxy %}accept-proxy{% endif %}
+    bind *:80 {% if KeepSource %}accept-proxy{% endif %}
     mode http
     option httplog
     option forwardfor
@@ -178,7 +178,7 @@ backend http-{{ svc.Name }}
 # tcp service
 {% for svc in TCPService %}
 frontend tcp-frontend-key-{{ svc.Port }}
-    bind *:{{ svc.Port }} {% if AcceptProxy %}accept-proxy{% endif %} {% if svc.SecretName %}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/{{ svc.SecretName }}.pem{% endif %} {%if svc.ALPNOptions %} {{svc.ALPNOptions}}{% endif %}
+    bind *:{{ svc.Port }} {% if KeepSource %}accept-proxy{% endif %} {% if svc.SecretName %}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/{{ svc.SecretName }}.pem{% endif %} {%if svc.ALPNOptions %} {{svc.ALPNOptions}}{% endif %}
     mode tcp
     default_backend tcp-{{ svc.Name }}
 {% endfor %}
@@ -204,7 +204,7 @@ backend tcp-{{ svc.Name }}
 
 {% if !HttpService and !HttpsService and DefaultBackend %}
 frontend http-frontend
-    bind *:80 {% if AcceptProxy %}accept-proxy{% endif %}
+    bind *:80 {% if KeepSource %}accept-proxy{% endif %}
     mode http
 
     option forwardfor

--- a/pkg/controller/ingress/template/template.go
+++ b/pkg/controller/ingress/template/template.go
@@ -93,7 +93,7 @@ backend default-backend
 {% if HttpsService %}
 # https service
 frontend https-frontend
-    bind *:443 {% if KeepSourceIP %}accept-proxy{% endif %} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/ alpn http/1.1
+    bind *:443 {% if AcceptProxy %}accept-proxy{% endif %} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/ alpn http/1.1
     # Mark all cookies as secure
     rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure
     # Add the HSTS header with a 6 month max-age
@@ -137,7 +137,7 @@ backend https-{{ svc.Name }}
 {% if HttpService %}
 # http services.
 frontend http-frontend
-    bind *:80 {% if KeepSourceIP %}accept-proxy{% endif %}
+    bind *:80 {% if AcceptProxy %}accept-proxy{% endif %}
     mode http
     option httplog
     option forwardfor
@@ -178,7 +178,7 @@ backend http-{{ svc.Name }}
 # tcp service
 {% for svc in TCPService %}
 frontend tcp-frontend-key-{{ svc.Port }}
-    bind *:{{ svc.Port }} {% if KeepSourceIP %}accept-proxy{% endif %} {% if svc.SecretName %}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/{{ svc.SecretName }}.pem{% endif %} {%if svc.ALPNOptions %} {{svc.ALPNOptions}}{% endif %}
+    bind *:{{ svc.Port }} {% if AcceptProxy %}accept-proxy{% endif %} {% if svc.SecretName %}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/{{ svc.SecretName }}.pem{% endif %} {%if svc.ALPNOptions %} {{svc.ALPNOptions}}{% endif %}
     mode tcp
     default_backend tcp-{{ svc.Name }}
 {% endfor %}
@@ -204,7 +204,7 @@ backend tcp-{{ svc.Name }}
 
 {% if !HttpService and !HttpsService and DefaultBackend %}
 frontend http-frontend
-    bind *:80 {% if KeepSourceIP %}accept-proxy{% endif %}
+    bind *:80 {% if AcceptProxy %}accept-proxy{% endif %}
     mode http
 
     option forwardfor

--- a/pkg/controller/ingress/template/template.go
+++ b/pkg/controller/ingress/template/template.go
@@ -93,7 +93,7 @@ backend default-backend
 {% if HttpsService %}
 # https service
 frontend https-frontend
-    bind *:443 {% if KeepSource %}accept-proxy{% endif %} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/ alpn http/1.1
+    bind *:443 {% if KeepSourceIP %}accept-proxy{% endif %} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/ alpn http/1.1
     # Mark all cookies as secure
     rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure
     # Add the HSTS header with a 6 month max-age
@@ -137,7 +137,7 @@ backend https-{{ svc.Name }}
 {% if HttpService %}
 # http services.
 frontend http-frontend
-    bind *:80 {% if KeepSource %}accept-proxy{% endif %}
+    bind *:80 {% if KeepSourceIP %}accept-proxy{% endif %}
     mode http
     option httplog
     option forwardfor
@@ -178,7 +178,7 @@ backend http-{{ svc.Name }}
 # tcp service
 {% for svc in TCPService %}
 frontend tcp-frontend-key-{{ svc.Port }}
-    bind *:{{ svc.Port }} {% if KeepSource %}accept-proxy{% endif %} {% if svc.SecretName %}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/{{ svc.SecretName }}.pem{% endif %} {%if svc.ALPNOptions %} {{svc.ALPNOptions}}{% endif %}
+    bind *:{{ svc.Port }} {% if KeepSourceIP %}accept-proxy{% endif %} {% if svc.SecretName %}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/{{ svc.SecretName }}.pem{% endif %} {%if svc.ALPNOptions %} {{svc.ALPNOptions}}{% endif %}
     mode tcp
     default_backend tcp-{{ svc.Name }}
 {% endfor %}
@@ -204,7 +204,7 @@ backend tcp-{{ svc.Name }}
 
 {% if !HttpService and !HttpsService and DefaultBackend %}
 frontend http-frontend
-    bind *:80 {% if KeepSource %}accept-proxy{% endif %}
+    bind *:80 {% if KeepSourceIP %}accept-proxy{% endif %}
     mode http
 
     option forwardfor

--- a/pkg/controller/ingress/types.go
+++ b/pkg/controller/ingress/types.go
@@ -78,7 +78,7 @@ const (
 	// X-Forwarded-For mechanism which is not always reliable and not even always
 	// usable. See also "tcp-request connection expect-proxy" for a finer-grained
 	// setting of which client is allowed to use the protocol.
-	LoadBalancerKeepSource = AnnotationPrefix + "keepSource"
+	LoadBalancerKeepSourceIP = AnnotationPrefix + "keep-source-ip"
 
 	// annotations applied to created resources for any ingress
 	LoadBalancerSourceAPIGroup = AnnotationPrefix + "source.apiGroup"
@@ -156,7 +156,7 @@ func (s annotation) LoadBalancerPersist() string {
 
 func (s annotation) ServiceAnnotations(provider, lbType string) (map[string]string, bool) {
 	m, ok := getTargetAnnotations(s, LoadBalancerServiceAnnotation)
-	if ok && lbType == LBTypeLoadBalancer && s.KeepSource() {
+	if ok && lbType == LBTypeLoadBalancer && s.KeepSourceIP() {
 		switch provider {
 		case "aws":
 			// ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79
@@ -173,8 +173,8 @@ func (s annotation) PodsAnnotations() (map[string]string, bool) {
 	return getTargetAnnotations(s, LoadBalancerPodsAnnotation)
 }
 
-func (s annotation) KeepSource() bool {
-	v, _ := s[LoadBalancerKeepSource]
+func (s annotation) KeepSourceIP() bool {
+	v, _ := s[LoadBalancerKeepSourceIP]
 	return strings.ToLower(v) == "true"
 }
 

--- a/pkg/controller/ingress/types.go
+++ b/pkg/controller/ingress/types.go
@@ -66,7 +66,14 @@ const (
 	// ex: "ingress.appscode.com/service.annotation": {"key": "val"}
 	LoadBalancerPodsAnnotation = AnnotationPrefix + "annotations.pod"
 
-	// Enforces the use of the PROXY protocol over any connection accepted by any of
+	// Preserves source IP for LoadBalancer type ingresses. The actual configuration
+	// generated depends on the underlying cloud provider.
+	//
+	//  - gce, gke, azure: Adds annotation service.beta.kubernetes.io/external-traffic: OnlyLocal
+	// to services used to expose HAProxy.
+	// ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+	//
+	// - aws: Enforces the use of the PROXY protocol over any connection accepted by any of
 	// the sockets declared on the same line. Versions 1 and 2 of the PROXY protocol
 	// are supported and correctly detected. The PROXY protocol dictates the layer
 	// 3/4 addresses of the incoming connection to be used everywhere an address is
@@ -78,6 +85,7 @@ const (
 	// X-Forwarded-For mechanism which is not always reliable and not even always
 	// usable. See also "tcp-request connection expect-proxy" for a finer-grained
 	// setting of which client is allowed to use the protocol.
+	// ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79
 	LoadBalancerKeepSourceIP = AnnotationPrefix + "keep-source-ip"
 
 	// annotations applied to created resources for any ingress

--- a/pkg/controller/ingress/update.go
+++ b/pkg/controller/ingress/update.go
@@ -262,8 +262,8 @@ func (lbc *EngressController) UpdateTargetAnnotations(old annotation, new annota
 	lbc.parse()
 
 	// Check for changes in ingress.appscode.com/annotations.service
-	if newSvcAns, newOk := new.ServiceAnnotations(); newOk {
-		if oldSvcAns, oldOk := old.ServiceAnnotations(); oldOk {
+	if newSvcAns, newOk := new.ServiceAnnotations(lbc.Options.ProviderName, lbc.Options.LBType); newOk {
+		if oldSvcAns, oldOk := old.ServiceAnnotations(lbc.Options.ProviderName, lbc.Options.LBType); oldOk {
 			if !reflect.DeepEqual(oldSvcAns, newSvcAns) {
 				svc, err := lbc.KubeClient.Core().Services(lbc.Config.Namespace).Get(VoyagerPrefix + lbc.Config.Name)
 				if err != nil {

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -1785,7 +1785,7 @@ func (ing *IngressTestSuit) TestIngressKeepSource() error {
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LoadBalancerKeepSource: "true",
+				ingress.LoadBalancerKeepSourceIP: "true",
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{
@@ -1860,7 +1860,7 @@ func (ing *IngressTestSuit) TestIngressLBSourceRange() error {
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LoadBalancerKeepSource: "true",
+				ingress.LoadBalancerKeepSourceIP: "true",
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -1779,13 +1779,13 @@ func (ing *IngressTestSuit) TestIngressStats() error {
 	return nil
 }
 
-func (ing *IngressTestSuit) TestIngressAcceptProxy() error {
+func (ing *IngressTestSuit) TestIngressKeepSource() error {
 	baseIngress := &aci.Ingress{
 		ObjectMeta: api.ObjectMeta{
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LoadBalancerAcceptProxy: "true",
+				ingress.LoadBalancerKeepSource: "true",
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{
@@ -1860,7 +1860,7 @@ func (ing *IngressTestSuit) TestIngressLBSourceRange() error {
 			Name:      testIngressName(),
 			Namespace: ing.t.Config.TestNamespace,
 			Annotations: map[string]string{
-				ingress.LoadBalancerAcceptProxy: "true",
+				ingress.LoadBalancerKeepSource: "true",
 			},
 		},
 		Spec: aci.ExtendedIngressSpec{


### PR DESCRIPTION
This preserves source IP for LoadBalancer type ingresses  for aws, gce, gke, azure. The actual configuration generated depends on the underlying cloud provider.

 - gce, gke, azure: Adds annotation service.beta.kubernetes.io/external-traffic: OnlyLocal
to services used to expose HAProxy.
ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer

- aws: Enforces the use of the PROXY protocol over any connection accepted by any of
the sockets declared on the same line. Versions 1 and 2 of the PROXY protocol
are supported and correctly detected. The PROXY protocol dictates the layer
3/4 addresses of the incoming connection to be used everywhere an address is
used, with the only exception of "tcp-request connection" rules which will
only see the real connection address. Logs will reflect the addresses
indicated in the protocol, unless it is violated, in which case the real
address will still be used.  This keyword combined with support from external
components can be used as an efficient and reliable alternative to the
X-Forwarded-For mechanism which is not always reliable and not even always
usable. See also "tcp-request connection expect-proxy" for a finer-grained
setting of which client is allowed to use the protocol.
ref: https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/cloudprovider/providers/aws/aws.go#L79  (this was implemented in #144)

Fixes #146, #100