### PR TITLE
Add voyager export command

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -1,160 +1,63 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 
 	hpe "github.com/appscode/haproxy_exporter/exporter"
+	"github.com/appscode/log"
 	"github.com/appscode/pat"
-	"github.com/appscode/voyager/api"
-	"github.com/orcaman/concurrent-map"
-	"github.com/prometheus/client_golang/prometheus"
+	_ "github.com/appscode/voyager/client/clientset/fake"
+	"github.com/appscode/voyager/pkg/analytics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/log"
-	"github.com/prometheus/common/version"
-	kerr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/spf13/cobra"
+	_ "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 )
 
-const (
-	ParamAPIGroup  = ":apiGroup"
-	ParamNamespace = ":namespace"
-	ParamName      = ":name"
-	ParamPodIP     = ":ip"
-)
+func NewCmdExport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export Prometheus metrics for HAProxy",
+		Run: func(cmd *cobra.Command, args []string) {
+			export()
+		},
+		PostRun: func(cmd *cobra.Command, args []string) {
+			analytics.ExporterStopped()
+		},
+	}
 
-var (
-	selectedServerMetrics map[int]*prometheus.GaugeVec
+	cmd.Flags().StringVar(&masterURL, "master", masterURL, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", kubeconfigPath, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
+	cmd.Flags().BoolVar(&enableAnalytics, "analytics", enableAnalytics, "Send analytical event to Google Analytics")
 
-	registerers = cmap.New() // URL.path => *prometheus.Registry
-)
+	cmd.Flags().StringVar(&address, "address", address, "Address to listen on for web interface and telemetry.")
+	cmd.Flags().StringVar(&haProxyServerMetricFields, "haproxy.server-metric-fields", haProxyServerMetricFields, "Comma-separated list of exported server metrics. See http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1")
+	cmd.Flags().DurationVar(&haProxyTimeout, "haproxy.timeout", haProxyTimeout, "Timeout for trying to get stats from HAProxy.")
 
-func DeleteRegistry(w http.ResponseWriter, r *http.Request) {
-	registerers.Remove(r.URL.Path)
-	w.WriteHeader(http.StatusOK)
+	return cmd
 }
 
-func ExportMetrics(w http.ResponseWriter, r *http.Request) {
-	params, found := pat.FromContext(r.Context())
-	if !found {
-		http.Error(w, "Missing parameters", http.StatusBadRequest)
-		return
-	}
-	apiGroup := params.Get(ParamAPIGroup)
-	if apiGroup == "" {
-		http.Error(w, "Missing parameter:"+ParamAPIGroup, http.StatusBadRequest)
-		return
-	}
-	namespace := params.Get(ParamNamespace)
-	if namespace == "" {
-		http.Error(w, "Missing parameter:"+ParamNamespace, http.StatusBadRequest)
-		return
-	}
-	name := params.Get(ParamName)
-	if name == "" {
-		http.Error(w, "Missing parameter:"+ParamName, http.StatusBadRequest)
-		return
-	}
-	podIP := params.Get(ParamPodIP)
-	if podIP == "" {
-		http.Error(w, "Missing parameter:"+ParamPodIP, http.StatusBadRequest)
-		return
+func export() {
+	if enableAnalytics {
+		analytics.Enable()
 	}
 
-	switch apiGroup {
-	case "extensions":
-		var reg *prometheus.Registry
-		if val, ok := registerers.Get(r.URL.Path); ok {
-			reg = val.(*prometheus.Registry)
-		} else {
-			reg = prometheus.NewRegistry()
-			if absent := registerers.SetIfAbsent(r.URL.Path, reg); !absent {
-				r2, _ := registerers.Get(r.URL.Path)
-				reg = r2.(*prometheus.Registry)
-			} else {
-				log.Infof("Configuring exporter for standard ingress %s in namespace %s", name, namespace)
-				ingress, err := kubeClient.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
-				if kerr.IsNotFound(err) {
-					http.NotFound(w, r)
-					return
-				} else if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				engress, err := api.NewEngressFromIngress(ingress)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				scrapeURL, err := getScrapeURL(engress, podIP)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				exporter, err := hpe.NewExporter(scrapeURL, selectedServerMetrics, haProxyTimeout)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				reg.MustRegister(exporter)
-				reg.MustRegister(version.NewCollector("haproxy_exporter"))
-			}
-		}
-		promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(w, r)
-		return
-	case "appscode.com":
-		var reg *prometheus.Registry
-		if val, ok := registerers.Get(r.URL.Path); ok {
-			reg = val.(*prometheus.Registry)
-		} else {
-			reg = prometheus.NewRegistry()
-			if absent := registerers.SetIfAbsent(r.URL.Path, reg); !absent {
-				r2, _ := registerers.Get(r.URL.Path)
-				reg = r2.(*prometheus.Registry)
-			} else {
-				log.Infof("Configuring exporter for appscode ingress %s in namespace %s", name, namespace)
-				engress, err := extClient.Ingress(namespace).Get(name)
-				if kerr.IsNotFound(err) {
-					http.NotFound(w, r)
-					return
-				} else if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				scrapeURL, err := getScrapeURL(engress, podIP)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				exporter, err := hpe.NewExporter(scrapeURL, selectedServerMetrics, haProxyTimeout)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				reg.MustRegister(exporter)
-				reg.MustRegister(version.NewCollector("haproxy_exporter"))
-			}
-		}
-		promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(w, r)
-		return
-	}
-	http.NotFound(w, r)
-}
+	log.Infoln("Starting Voyager exporter...")
+	analytics.ExporterStarted()
 
-func getScrapeURL(r *api.Ingress, podIP string) (string, error) {
-	if !r.Stats() {
-		return "", errors.New("Stats not exposed")
-	}
-	if r.StatsSecretName() != "" {
-		return fmt.Sprintf("http://%s:%d?stats;csv", podIP, r.StatsPort()), nil
-	}
-	secret, err := kubeClient.CoreV1().Secrets(r.Namespace).Get(r.StatsSecretName(), metav1.GetOptions{})
+	var err error
+	selectedServerMetrics, err = hpe.FilterServerMetrics(haProxyServerMetricFields)
 	if err != nil {
-		return "", err
+		log.Fatal(err)
 	}
-	userName := string(secret.Data["username"])
-	passWord := string(secret.Data["password"])
-	return fmt.Sprintf("http://%s:%s@%s:%d?stats;csv", userName, passWord, podIP, r.StatsPort()), nil
+	m := pat.New()
+	m.Get("/metrics", promhttp.Handler())
+	pattern := fmt.Sprintf("/%s/v1beta1/namespaces/%s/ingresses/%s/metrics", PathParamAPIGroup, PathParamNamespace, PathParamName)
+	log.Infof("URL pattern: %s", pattern)
+	m.Get(pattern, http.HandlerFunc(ExportMetrics))
+	m.Del(pattern, http.HandlerFunc(DeleteRegistry))
+	http.Handle("/", m)
+	log.Infoln("Listening on", address)
+	log.Fatal(http.ListenAndServe(address, nil))
 }

--- a/exporter.go
+++ b/exporter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/appscode/voyager/pkg/analytics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
-	_ "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 )
 
 func NewCmdExport() *cobra.Command {

--- a/exporter_handler.go
+++ b/exporter_handler.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+
+	hpe "github.com/appscode/haproxy_exporter/exporter"
+	"github.com/appscode/pat"
+	"github.com/appscode/voyager/api"
+	"github.com/orcaman/concurrent-map"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/log"
+	"github.com/prometheus/common/version"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	PathParamAPIGroup  = ":apiGroup"
+	PathParamNamespace = ":namespace"
+	PathParamName      = ":name"
+	QueryParamPodIP    = "pod"
+)
+
+var (
+	selectedServerMetrics map[int]*prometheus.GaugeVec
+
+	registerers = cmap.New() // URL.path => *prometheus.Registry
+)
+
+func DeleteRegistry(w http.ResponseWriter, r *http.Request) {
+	registerers.Remove(r.URL.Path)
+	w.WriteHeader(http.StatusOK)
+}
+
+func ExportMetrics(w http.ResponseWriter, r *http.Request) {
+	params, found := pat.FromContext(r.Context())
+	if !found {
+		http.Error(w, "Missing parameters", http.StatusBadRequest)
+		return
+	}
+	apiGroup := params.Get(PathParamAPIGroup)
+	if apiGroup == "" {
+		http.Error(w, "Missing parameter:"+PathParamAPIGroup, http.StatusBadRequest)
+		return
+	}
+	namespace := params.Get(PathParamNamespace)
+	if namespace == "" {
+		http.Error(w, "Missing parameter:"+PathParamNamespace, http.StatusBadRequest)
+		return
+	}
+	name := params.Get(PathParamName)
+	if name == "" {
+		http.Error(w, "Missing parameter:"+PathParamName, http.StatusBadRequest)
+		return
+	}
+	podIP := r.URL.Query().Get(QueryParamPodIP)
+	if podIP == "" {
+		podIP = "127.0.0.1"
+		return
+	}
+
+	switch apiGroup {
+	case "extensions":
+		var reg *prometheus.Registry
+		if val, ok := registerers.Get(r.URL.Path); ok {
+			reg = val.(*prometheus.Registry)
+		} else {
+			reg = prometheus.NewRegistry()
+			if absent := registerers.SetIfAbsent(r.URL.Path, reg); !absent {
+				r2, _ := registerers.Get(r.URL.Path)
+				reg = r2.(*prometheus.Registry)
+			} else {
+				log.Infof("Configuring exporter for standard ingress %s in namespace %s", name, namespace)
+				ingress, err := kubeClient.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
+				if kerr.IsNotFound(err) {
+					http.NotFound(w, r)
+					return
+				} else if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				engress, err := api.NewEngressFromIngress(ingress)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				scrapeURL, err := getScrapeURL(engress, podIP)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				exporter, err := hpe.NewExporter(scrapeURL, selectedServerMetrics, haProxyTimeout)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				reg.MustRegister(exporter)
+				reg.MustRegister(version.NewCollector("haproxy_exporter"))
+			}
+		}
+		promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+		return
+	case "appscode.com":
+		var reg *prometheus.Registry
+		if val, ok := registerers.Get(r.URL.Path); ok {
+			reg = val.(*prometheus.Registry)
+		} else {
+			reg = prometheus.NewRegistry()
+			if absent := registerers.SetIfAbsent(r.URL.Path, reg); !absent {
+				r2, _ := registerers.Get(r.URL.Path)
+				reg = r2.(*prometheus.Registry)
+			} else {
+				log.Infof("Configuring exporter for appscode ingress %s in namespace %s", name, namespace)
+				engress, err := extClient.Ingress(namespace).Get(name)
+				if kerr.IsNotFound(err) {
+					http.NotFound(w, r)
+					return
+				} else if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				scrapeURL, err := getScrapeURL(engress, podIP)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				exporter, err := hpe.NewExporter(scrapeURL, selectedServerMetrics, haProxyTimeout)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				reg.MustRegister(exporter)
+				reg.MustRegister(version.NewCollector("haproxy_exporter"))
+			}
+		}
+		promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func getScrapeURL(r *api.Ingress, podIP string) (string, error) {
+	if !r.Stats() {
+		return "", errors.New("Stats not exposed")
+	}
+	if r.StatsSecretName() != "" {
+		return fmt.Sprintf("http://%s:%d?stats;csv", podIP, r.StatsPort()), nil
+	}
+	secret, err := kubeClient.CoreV1().Secrets(r.Namespace).Get(r.StatsSecretName(), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	userName := string(secret.Data["username"])
+	passWord := string(secret.Data["password"])
+	return fmt.Sprintf("http://%s:%s@%s:%d?stats;csv", userName, passWord, podIP, r.StatsPort()), nil
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	logs.InitLogs()
 
 	rootCmd.AddCommand(NewCmdRun())
+	rootCmd.AddCommand(NewCmdExport())
 	rootCmd.AddCommand(v.NewCmdVersion())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -50,12 +50,20 @@ func mustNewClient() *ga.Client {
 	return client
 }
 
-func VoyagerStarted() {
+func OperatorStarted() {
 	send(ga.NewEvent("operator", "started"))
 }
 
-func VoyagerStopped() {
+func OperatorStopped() {
 	send(ga.NewEvent("operator", "stopped"))
+}
+
+func ExporterStarted() {
+	send(ga.NewEvent("exporter", "started"))
+}
+
+func ExporterStopped() {
+	send(ga.NewEvent("exporter", "stopped"))
 }
 
 func Send(category, action string, label ...string) {

--- a/run.go
+++ b/run.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	_ "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 )
 
 var (


### PR DESCRIPTION
ref : #154 

This is fast part of running voyager as side-car exporter. URL structure for metrics is changed from 

`/%s/v1beta1/namespaces/%s/ingresses/%s/pod/%s/metrics` --->
`/%s/v1beta1/namespaces/%s/ingresses/%s/metrics?pod=<ip>`

If pod is missing, ip is considered 127.0.0.1