### PR TITLE
Update default ports

### DIFF
--- a/api/annotations.go
+++ b/api/annotations.go
@@ -23,7 +23,7 @@ const (
 	StatsPort        = EngressKey + "/" + "stats-port"
 	StatsSecret      = EngressKey + "/" + "stats-secret-name"
 	StatsServiceName = EngressKey + "/" + "stats-service-name"
-	DefaultStatsPort = 1936
+	DefaultStatsPort = 56789
 
 	LBTypeHostPort     = "HostPort"
 	LBTypeNodePort     = "NodePort"

--- a/api/monitor.go
+++ b/api/monitor.go
@@ -3,7 +3,7 @@ package api
 import "fmt"
 
 const (
-	AgentCoreosPrometheus = "COREOS_PROMETHEUS"
+	AgentCoreosPrometheus = "coreos-prometheus-operator"
 
 	MonitoringAgent              = EngressKey + "/monitoring-agent"                         // COREOS_PROMETHEUS
 	PrometheusExporterPort       = EngressKey + "/prometheus-exporter-port"                 // Kube NS where service monitors will be created

--- a/api/monitor.go
+++ b/api/monitor.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	AgentCoreosPrometheus = "coreos-prometheus-operator"
-	DefaultExporterPort = 56790
+	DefaultExporterPort   = 56790
 
 	MonitoringAgent              = EngressKey + "/monitoring-agent"                         // COREOS_PROMETHEUS
 	PrometheusExporterPort       = EngressKey + "/prometheus-exporter-port"                 // Kube NS where service monitors will be created

--- a/api/monitor.go
+++ b/api/monitor.go
@@ -4,6 +4,7 @@ import "fmt"
 
 const (
 	AgentCoreosPrometheus = "coreos-prometheus-operator"
+	DefaultExporterPort = 56790
 
 	MonitoringAgent              = EngressKey + "/monitoring-agent"                         // COREOS_PROMETHEUS
 	PrometheusExporterPort       = EngressKey + "/prometheus-exporter-port"                 // Kube NS where service monitors will be created
@@ -62,7 +63,7 @@ func (r Ingress) MonitorSpec() (*MonitorSpec, error) {
 		return nil, err
 	}
 	if prom.ExporterPort == 0 {
-		prom.ExporterPort = 56789
+		prom.ExporterPort = DefaultExporterPort
 	}
 
 	prom.Interval = getString(r.Annotations, ServiceMonitorScrapeInterval)

--- a/chart/voyager/templates/deployment.yaml
+++ b/chart/voyager/templates/deployment.yaml
@@ -27,6 +27,6 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         name: voyager
         ports:
-        - containerPort: 8080
+        - containerPort: 56790
           name: http
           protocol: TCP

--- a/chart/voyager/templates/svc.yaml
+++ b/chart/voyager/templates/svc.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
+    port: 56790
     targetPort: http
   selector:
     app: {{ template "name" . }}

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -26,7 +26,7 @@ Now Create Your Ingress/Certificated.
 
 #### Configuration Options
 ```
-      --address string                        Address to listen on for web interface and telemetry. (default ":8080")
+      --address string                        Address to listen on for web interface and telemetry. (default ":56790")
       --analytics                             Send analytical event to Google Analytics (default true)
   -c, --cloud-provider string                 Name of cloud provider
       --haproxy-image string                  haproxy image name to be run (default "appscode/haproxy:1.7.6-3.0.0")

--- a/docs/user-guide/ingress/README.md
+++ b/docs/user-guide/ingress/README.md
@@ -130,7 +130,7 @@ Below is the full list of supported annotation keys:
 | ingress.appscode.com/annotations-pod | map | x | `Optional`. Annotations applied to pods used to run HAProxy |
 | ingress.appscode.com/keep-source-ip | bool | false | `Optional`. If set, preserves source IP for `LoadBalancer` type ingresses. The actual configuration generated depends on the underlying cloud provider. For gce, gke, azure: Adds annotation `service.beta.kubernetes.io/external-traffic: OnlyLocal` to services used to expose HAProxy. For aws, enforces the use of the PROXY protocol. |
 | ingress.appscode.com/stats | bool | false | `Optional`. If set, HAProxy stats will be exposed |
-| ingress.appscode.com/stats-port | integer | 1936 | `Optional`. Port used to expose HAProxy stats |
+| ingress.appscode.com/stats-port | integer | 56789 | `Optional`. Port used to expose HAProxy stats |
 | ingress.appscode.com/stats-secret-name | string | x | `Optional`. Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
 | ingress.appscode.com/ip | | | Removed since 1.5.6. Use `ingress.appscode.com/load-balaner-ip` |
 | ingress.appscode.com/persist | | | Removed since 1.5.6. |

--- a/docs/user-guide/ingress/README.md
+++ b/docs/user-guide/ingress/README.md
@@ -121,17 +121,17 @@ Below is the full list of supported annotation keys:
 
 |  Keys  |   Value   |  Default |  Description |
 |--------|-----------|----------|--------------|
-| ingress.appscode.com/type | LoadBalancer, HostPort, NodePort | LoadBalancer | Indicates type of service used to expose HAProxy to the internet |
-| ingress.appscode.com/replicas | integer | 1 | Indicates number of replicas of HAProxy pods |
-| ingress.appscode.com/load-balaner-ip | string | x | For "gce" and "gke" cloud provider, if this value is set to a valid IPv4 address, it will be assigned to Google cloud network loadbalancer used to expose HAProxy. Usually this is set to a static IP to preserve DNS configuration |
+| ingress.appscode.com/type | LoadBalancer, HostPort, NodePort | LoadBalancer | `Required`. Indicates type of service used to expose HAProxy to the internet |
+| ingress.appscode.com/replicas | integer | 1 | `Optional`. Indicates number of replicas of HAProxy pods |
+| ingress.appscode.com/load-balaner-ip | string | x | `Optional`. For "gce" and "gke" cloud provider, if this value is set to a valid IPv4 address, it will be assigned to Google cloud network loadbalancer used to expose HAProxy. Usually this is set to a static IP to preserve DNS configuration |
 | ingress.appscode.com/node-selector | map | x | Indicates which hosts are selected to run HAProxy pods. This is a required annotation for `HostPort` type ingress. |
-| ingress.appscode.com/sticky-session | bool | false | Indicates the session affinity for the traffic. If set, session affinity will apply to all the rulses. |
-| ingress.appscode.com/annotations-service | map | x | Annotaiotns applied to service used to expose HAProxy |
-| ingress.appscode.com/annotations-pod | map | x | Annotations applied to pods used to run HAProxy |
-| ingress.appscode.com/keep-source-ip | bool | false | If set, preserves source IP for `LoadBalancer` type ingresses. The actual configuration generated depends on the underlying cloud provider. For gce, gke, azure: Adds annotation `service.beta.kubernetes.io/external-traffic: OnlyLocal` to services used to expose HAProxy. For aws, enforces the use of the PROXY protocol. |
-| ingress.appscode.com/stats | bool | false | If set, HAProxy stats will be exposed |
-| ingress.appscode.com/stats-port | integer | 1936 | Port used to expose HAProxy stats |
-| ingress.appscode.com/stats-secret-name | string | x | Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
+| ingress.appscode.com/sticky-session | bool | false | `Optional`. Indicates the session affinity for the traffic. If set, session affinity will apply to all the rulses. |
+| ingress.appscode.com/annotations-service | map | x | `Optional`. Annotaiotns applied to service used to expose HAProxy |
+| ingress.appscode.com/annotations-pod | map | x | `Optional`. Annotations applied to pods used to run HAProxy |
+| ingress.appscode.com/keep-source-ip | bool | false | `Optional`. If set, preserves source IP for `LoadBalancer` type ingresses. The actual configuration generated depends on the underlying cloud provider. For gce, gke, azure: Adds annotation `service.beta.kubernetes.io/external-traffic: OnlyLocal` to services used to expose HAProxy. For aws, enforces the use of the PROXY protocol. |
+| ingress.appscode.com/stats | bool | false | `Optional`. If set, HAProxy stats will be exposed |
+| ingress.appscode.com/stats-port | integer | 1936 | `Optional`. Port used to expose HAProxy stats |
+| ingress.appscode.com/stats-secret-name | string | x | `Optional`. Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
 | ingress.appscode.com/ip | | | Removed since 1.5.6. Use `ingress.appscode.com/load-balaner-ip` |
 | ingress.appscode.com/persist | | | Removed since 1.5.6. |
 | ingress.appscode.com/daemon.nodeSelector | | | Removed since 1.5.6. Use `ingress.appscode.com/node-selector` |

--- a/docs/user-guide/ingress/external-svc.md
+++ b/docs/user-guide/ingress/external-svc.md
@@ -9,10 +9,10 @@ dns, [DNS resolvers](https://cbonte.github.io/haproxy-dconv/1.7/configuration.ht
 |  Keys  |   Value  |  Default |  Description |
 |--------|-----------|----------|-------------|
 | ingress.appscode.com/use-dns-resolver | bool | false for L7, always true for L4 | If set, DNS resolution will be used |
-| ingress.appscode.com/dns-resolver-nameservers | array | | If set to an array of DNS nameservers, these will be used HAProxy to periodically resolve DNS. If not set, HAProxy parses the server line definition and matches a host name at start up. |
-| ingress.appscode.com/dns-resolver-retries | integer | | If set, this defines the number of queries to send to resolve a server name before giving up. If not set, default value pre-configured by HAProxy is used. |
-| ingress.appscode.com/dns-resolver-timeout | map | | If set, defines timeouts related to name resolution. Define value as '{ "event": "time" }'. For a list of valid events, please consult [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#5.3.2-timeout). |
-| ingress.appscode.com/dns-resolver-hold | map | | If set, Defines period during which the last name resolution should be kept based on last resolution status. Define value as '{ "status": "period" }'. For a list of valid status, please consult [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#5.3.2-hold). |
+| ingress.appscode.com/dns-resolver-nameservers | array | | `Optional`. If set to an array of DNS nameservers, these will be used HAProxy to periodically resolve DNS. If not set, HAProxy parses the server line definition and matches a host name at start up. |
+| ingress.appscode.com/dns-resolver-retries | integer | | `Optional`. If set, this defines the number of queries to send to resolve a server name before giving up. If not set, default value pre-configured by HAProxy is used. |
+| ingress.appscode.com/dns-resolver-timeout | map | | `Optional`. If set, defines timeouts related to name resolution. Define value as '{ "event": "time" }'. For a list of valid events, please consult [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#5.3.2-timeout). |
+| ingress.appscode.com/dns-resolver-hold | map | | `Optional`. If set, Defines period during which the last name resolution should be kept based on last resolution status. Define value as '{ "status": "period" }'. For a list of valid status, please consult [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#5.3.2-hold). |
 
 Following example illustrates the scenario.
 

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -5,7 +5,7 @@ To expose HAProxy stats, please use the following annotations:
 |  Keys  |   Value  |  Default |  Description |
 |--------|-----------|----------|-------------|
 | ingress.appscode.com/stats | bool | false | `Optional`. If set, HAProxy stats will be exposed |
-| ingress.appscode.com/stats-port | integer | 1936 | `Optional`. Port used to expose HAProxy stats |
+| ingress.appscode.com/stats-port | integer | 56789 | `Optional`. Port used to expose HAProxy stats |
 | ingress.appscode.com/stats-secret-name | string | x | `Optional`. Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
 
 Please note that stats port is not exposed to the internet via the service running in front of HAProxy pods.
@@ -20,7 +20,7 @@ Voyager operator exposes Prometheus ready metrics via the following endpoints on
 To change the port, use `--address` flag on Voyager opreator.
 
 ## Using [CoreOS Prometheus Operator](https://coreos.com/operators/prometheus/docs/latest/)
-Voyager operator can create [service monitors](https://coreos.com/operators/prometheus/docs/latest/user-guides/running-exporters.html#create-a-matching-servicemonitor) for HAProxy pods. If enabled, a side-car exporter pod is run with HAProxy to expose Prometheus ready metrics via the following endpoints on port `:56789`:
+Voyager operator can create [service monitors](https://coreos.com/operators/prometheus/docs/latest/user-guides/running-exporters.html#create-a-matching-servicemonitor) for HAProxy pods. If enabled, a side-car exporter pod is run with HAProxy to expose Prometheus ready metrics via the following endpoints on port `:56790`:
 
  - `/extensions/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics` :  Scrape this endpoint to monitor HAProxy running for a Kubernetes ingress
  - `/voyager.appscode.com/v1beta1/namespaces/:ns/ingresses/:name/metrics`: Scrape this endpoint to monitor HAProxy running for an AppsCode extended ingress
@@ -30,7 +30,7 @@ To enable this feature, please use the following annotations:
 |  Keys  |   Value  |  Default |  Description |
 |--------|-----------|----------|-------------|
 | ingress.appscode.com/monitoring-agent | string | | `Required`. Indicates the monitoring agent used. Only valid value currently is 'coreos-prometheus-operator' |
-| ingress.appscode.com/prometheus-exporter-port| integer | 56789 | `Optional`. Indicates the port used by exporter side-car to expose Prometheus metrics endpoint. If the default port 56789 is used to expose traffic, change it to an unused port. |
+| ingress.appscode.com/prometheus-exporter-port| integer | 56790 | `Optional`. Indicates the port used by exporter side-car to expose Prometheus metrics endpoint. If the default port 56790 is used to expose traffic, change it to an unused port. |
 | ingress.appscode.com/service-monitor-labels | map | | `Required`. Indicates labels applied to service monitor. |
 | ingress.appscode.com/service-monitor-namespace| string | | `Required`. Indicates namespace where service monitors are created. This must be the same namespace of the Prometheus instance. |
 | ingress.appscode.com/service-monitor-endpoint-scrape-interval | string | | `Optional`. Indicates the srace interval for HAProxy exporter endpoint

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -29,10 +29,10 @@ To enable this feature, please use the following annotations:
 
 |  Keys  |   Value  |  Default |  Description |
 |--------|-----------|----------|-------------|
-| ingress.appscode.com/monitoring-agent | string | | Required. Indicates the monitoring agent used. Only valid value currently is 'coreos-prometheus-operator' |
-| ingress.appscode.com/prometheus-exporter-port| integer | 56789 | Indicates the port used by exporter side-car to expose Prometheus metrics endpoint. If the default port 56789 is used to expose traffic, change it to an unused port. |
-| ingress.appscode.com/service-monitor-labels | map | | Required. Indicates labels applied to service monitor. |
-| ingress.appscode.com/service-monitor-namespace| string | | Required. Indicates namespace where service monitors are created. This must be the same namespace of the Prometheus instance. |
-| ingress.appscode.com/service-monitor-endpoint-scrape-interval | string | | Optional. Indicates the srace interval for HAProxy exporter endpoint
+| ingress.appscode.com/monitoring-agent | string | | `Required`. Indicates the monitoring agent used. Only valid value currently is 'coreos-prometheus-operator' |
+| ingress.appscode.com/prometheus-exporter-port| integer | 56789 | `Optional`. Indicates the port used by exporter side-car to expose Prometheus metrics endpoint. If the default port 56789 is used to expose traffic, change it to an unused port. |
+| ingress.appscode.com/service-monitor-labels | map | | `Required`. Indicates labels applied to service monitor. |
+| ingress.appscode.com/service-monitor-namespace| string | | `Required`. Indicates namespace where service monitors are created. This must be the same namespace of the Prometheus instance. |
+| ingress.appscode.com/service-monitor-endpoint-scrape-interval | string | | `Optional`. Indicates the srace interval for HAProxy exporter endpoint
 
 Known Limitations: If the HAProxy stats password is updated, exporter must be restarted to use the credentials. This issue is tracked [here](https://github.com/appscode/voyager/issues/212).

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -19,7 +19,7 @@ Voyager operator exposes Prometheus ready metrics via the following endpoints on
 
 To change the port, use `--address` flag on Voyager opreator.
 
-## Using CoreOS Prometheus Operator
+## Using [CoreOS Prometheus Operator](https://coreos.com/operators/prometheus/docs/latest/)
 Voyager operator can create [service monitors](https://coreos.com/operators/prometheus/docs/latest/user-guides/running-exporters.html#create-a-matching-servicemonitor) for HAProxy pods. If enabled, a side-car exporter pod is run with HAProxy to expose Prometheus ready metrics via the following endpoints on port `:56789`:
 
  - `/extensions/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics` :  Scrape this endpoint to monitor HAProxy running for a Kubernetes ingress

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -20,7 +20,7 @@ Voyager operator exposes Prometheus ready metrics via the following endpoints on
 To change the port, use `--address` flag on Voyager opreator.
 
 ## Using CoreOS Prometheus Operator
-Voyager operator can create service monitors for HAProxy pods. If enabled, a side-car exporter pod is run with HAProxy to expose Prometheus ready metrics via the following endpoints on port `:56789`:
+Voyager operator can create [service monitors](https://coreos.com/operators/prometheus/docs/latest/user-guides/running-exporters.html#create-a-matching-servicemonitor) for HAProxy pods. If enabled, a side-car exporter pod is run with HAProxy to expose Prometheus ready metrics via the following endpoints on port `:56789`:
 
  - `/extensions/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics` :  Scrape this endpoint to monitor HAProxy running for a Kubernetes ingress
  - `/voyager.appscode.com/v1beta1/namespaces/:ns/ingresses/:name/metrics`: Scrape this endpoint to monitor HAProxy running for an AppsCode extended ingress

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -4,9 +4,9 @@ To expose HAProxy stats, please use the following annotations:
 ### Stats annotations
 |  Keys  |   Value  |  Default |  Description |
 |--------|-----------|----------|-------------|
-| ingress.appscode.com/stats | bool | false | If set, HAProxy stats will be exposed |
-| ingress.appscode.com/stats-port | integer | 1936 | Port used to expose HAProxy stats |
-| ingress.appscode.com/stats-secret-name | string | x | Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
+| ingress.appscode.com/stats | bool | false | `Optional`. If set, HAProxy stats will be exposed |
+| ingress.appscode.com/stats-port | integer | 1936 | `Optional`. Port used to expose HAProxy stats |
+| ingress.appscode.com/stats-secret-name | string | x | `Optional`. Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
 
 Please note that stats port is not exposed to the internet via the service running in front of HAProxy pods.
 

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -7,9 +7,8 @@ To expose HAProxy stats, please use the following annotations:
 | ingress.appscode.com/stats | bool | false | If set, HAProxy stats will be exposed |
 | ingress.appscode.com/stats-port | integer | 1936 | Port used to expose HAProxy stats |
 | ingress.appscode.com/stats-secret-name | string | x | Secret used to provide username & password to secure HAProxy stats endpoint. Secret must contain keys `username` and `password` |
-| ingress.appscode.com/stats-service-name | string | `<ingress-name>-stats` | ClusterIP type service used to expose HAproxy stats. This allows to avoid exposing stats to internet. |
 
-Please note that a separate `ClusterIP` type service is used to expose stats. So, you can use expose unauthenticated stats endpoint without exposing them to the internet.
+Please note that stats port is not exposed to the internet via the service running in front of HAProxy pods.
 
 ## Using Prometheus
 Voyager operator exposes Prometheus ready metrics via the following endpoints on port `:8080`:
@@ -19,5 +18,9 @@ Voyager operator exposes Prometheus ready metrics via the following endpoints on
  - `/voyager.appscode.com/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics`: Scrape this endpoint to monitor HAProxy running for an AppsCode extended ingress
 
 To change the port, use `--address` flag on Voyager opreator.
+
+## Using CoreOS Prometheus Operator
+
+
 
 Currently [further discussion is on-going](https://github.com/appscode/voyager/issues/154) on how to integrate this with CoreOS Prometheus Operator.

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -15,12 +15,24 @@ Voyager operator exposes Prometheus ready metrics via the following endpoints on
 
  - `/metrics`: Scrape this to monitor operator.
  - `/extensions/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics` :  Scrape this endpoint to monitor HAProxy running for a Kubernetes ingress
- - `/voyager.appscode.com/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics`: Scrape this endpoint to monitor HAProxy running for an AppsCode extended ingress
+ - `/voyager.appscode.com/v1beta1/namespaces/:ns/ingresses/:name/metrics`: Scrape this endpoint to monitor HAProxy running for an AppsCode extended ingress
 
 To change the port, use `--address` flag on Voyager opreator.
 
 ## Using CoreOS Prometheus Operator
+Voyager operator can create service monitors for HAProxy pods. If enabled, a side-car exporter pod is run with HAProxy to expose Prometheus ready metrics via the following endpoints on port `:56789`:
 
+ - `/extensions/v1beta1/namespaces/:ns/ingresses/:name/pods/:ip/metrics` :  Scrape this endpoint to monitor HAProxy running for a Kubernetes ingress
+ - `/voyager.appscode.com/v1beta1/namespaces/:ns/ingresses/:name/metrics`: Scrape this endpoint to monitor HAProxy running for an AppsCode extended ingress
 
+To enable this feature, please use the following annotations: 
 
-Currently [further discussion is on-going](https://github.com/appscode/voyager/issues/154) on how to integrate this with CoreOS Prometheus Operator.
+|  Keys  |   Value  |  Default |  Description |
+|--------|-----------|----------|-------------|
+| ingress.appscode.com/monitoring-agent | string | | Required. Indicates the monitoring agent used. Only valid value currently is 'coreos-prometheus-operator' |
+| ingress.appscode.com/prometheus-exporter-port| integer | 56789 | Indicates the port used by exporter side-car to expose Prometheus metrics endpoint. If the default port 56789 is used to expose traffic, change it to an unused port. |
+| ingress.appscode.com/service-monitor-labels | map | | Required. Indicates labels applied to service monitor. |
+| ingress.appscode.com/service-monitor-namespace| string | | Required. Indicates namespace where service monitors are created. This must be the same namespace of the Prometheus instance. |
+| ingress.appscode.com/service-monitor-endpoint-scrape-interval | string | | Optional. Indicates the srace interval for HAProxy exporter endpoint
+
+Known Limitations: If the HAProxy stats password is updated, exporter must be restarted to use the credentials. This issue is tracked [here](https://github.com/appscode/voyager/issues/212).

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -35,4 +35,4 @@ To enable this feature, please use the following annotations:
 | ingress.appscode.com/service-monitor-namespace| string | | `Required`. Indicates namespace where service monitors are created. This must be the same namespace of the Prometheus instance. |
 | ingress.appscode.com/service-monitor-endpoint-scrape-interval | string | | `Optional`. Indicates the srace interval for HAProxy exporter endpoint
 
-Known Limitations: If the HAProxy stats password is updated, exporter must be restarted to use the credentials. This issue is tracked [here](https://github.com/appscode/voyager/issues/212).
+__Known Limitations:__ If the HAProxy stats password is updated, exporter must be restarted to use the credentials. This issue is tracked [here](https://github.com/appscode/voyager/issues/212).

--- a/docs/user-guide/ingress/stats-and-metrics.md
+++ b/docs/user-guide/ingress/stats-and-metrics.md
@@ -35,4 +35,4 @@ To enable this feature, please use the following annotations:
 | ingress.appscode.com/service-monitor-namespace| string | | `Required`. Indicates namespace where service monitors are created. This must be the same namespace of the Prometheus instance. |
 | ingress.appscode.com/service-monitor-endpoint-scrape-interval | string | | `Optional`. Indicates the srace interval for HAProxy exporter endpoint
 
-__Known Limitations:__ If the HAProxy stats password is updated, exporter must be restarted to use the credentials. This issue is tracked [here](https://github.com/appscode/voyager/issues/212).
+__Known Limitations:__ If the HAProxy stats password is updated, exporter must be restarted to use the new credentials. This issue is tracked [here](https://github.com/appscode/voyager/issues/212).

--- a/hack/deploy/deployments.yaml
+++ b/hack/deploy/deployments.yaml
@@ -23,7 +23,7 @@ spec:
         - --v=3
         image: appscode/voyager:$TAG
         ports:
-        - containerPort: 8080
+        - containerPort: 56790
           name: http
           protocol: TCP
 ---
@@ -37,7 +37,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
+    port: 56790
     targetPort: http
   selector:
     app: voyager-operator

--- a/pkg/certificates/providers/http.go
+++ b/pkg/certificates/providers/http.go
@@ -86,7 +86,7 @@ func (s *HTTPProviderServer) serve() {
 
 			httpServer := &http.Server{
 				Handler: mux,
-				Addr:    ":56789",
+				Addr:    ":56788",
 			}
 			// Once httpServer is shut down we don't want any lingering
 			// connections, so disable KeepAlives.

--- a/pkg/certificates/providers/http.go
+++ b/pkg/certificates/providers/http.go
@@ -86,7 +86,7 @@ func (s *HTTPProviderServer) serve() {
 
 			httpServer := &http.Server{
 				Handler: mux,
-				Addr:    ":56788",
+				Addr:    ":56791",
 			}
 			// Once httpServer is shut down we don't want any lingering
 			// connections, so disable KeepAlives.

--- a/pkg/certificates/providers/http_test.go
+++ b/pkg/certificates/providers/http_test.go
@@ -16,7 +16,7 @@ func init() {
 func TestNotFound(t *testing.T) {
 	defaultHTTPProvider.serve()
 	time.Sleep(time.Second * 5)
-	resp, err := http.Get("http://127.0.0.1:56788" + URLPrefix + "token")
+	resp, err := http.Get("http://127.0.0.1:56791" + URLPrefix + "token")
 	if err != nil {
 		t.Fatal("expected Nil, found", err)
 	}
@@ -38,8 +38,8 @@ func TestNotFound(t *testing.T) {
 func TestFound(t *testing.T) {
 	defaultHTTPProvider.serve()
 	time.Sleep(time.Second * 5)
-	defaultHTTPProvider.Present("127.0.0.1:56788", "token", "key")
-	resp, err := http.Get("http://127.0.0.1:56788" + URLPrefix + "token")
+	defaultHTTPProvider.Present("127.0.0.1:56791", "token", "key")
+	resp, err := http.Get("http://127.0.0.1:56791" + URLPrefix + "token")
 	if err != nil {
 		t.Fatal("expected Nil, found", err)
 	}

--- a/pkg/certificates/providers/http_test.go
+++ b/pkg/certificates/providers/http_test.go
@@ -16,7 +16,7 @@ func init() {
 func TestNotFound(t *testing.T) {
 	defaultHTTPProvider.serve()
 	time.Sleep(time.Second * 5)
-	resp, err := http.Get("http://127.0.0.1:56789" + URLPrefix + "token")
+	resp, err := http.Get("http://127.0.0.1:56788" + URLPrefix + "token")
 	if err != nil {
 		t.Fatal("expected Nil, found", err)
 	}
@@ -38,8 +38,8 @@ func TestNotFound(t *testing.T) {
 func TestFound(t *testing.T) {
 	defaultHTTPProvider.serve()
 	time.Sleep(time.Second * 5)
-	defaultHTTPProvider.Present("127.0.0.1:56789", "token", "key")
-	resp, err := http.Get("http://127.0.0.1:56789" + URLPrefix + "token")
+	defaultHTTPProvider.Present("127.0.0.1:56788", "token", "key")
+	resp, err := http.Get("http://127.0.0.1:56788" + URLPrefix + "token")
 	if err != nil {
 		t.Fatal("expected Nil, found", err)
 	}

--- a/run.go
+++ b/run.go
@@ -9,6 +9,7 @@ import (
 	hpe "github.com/appscode/haproxy_exporter/exporter"
 	"github.com/appscode/log"
 	"github.com/appscode/pat"
+	"github.com/appscode/voyager/api"
 	acs "github.com/appscode/voyager/client/clientset"
 	_ "github.com/appscode/voyager/client/clientset/fake"
 	"github.com/appscode/voyager/pkg/analytics"
@@ -29,7 +30,7 @@ var (
 	ingressClass    string
 	enableAnalytics bool = true
 
-	address                   string        = ":8080"
+	address                   string        = fmt.Sprintf(":%d", api.DefaultExporterPort)
 	haProxyServerMetricFields string        = hpe.ServerMetrics.String()
 	haProxyTimeout            time.Duration = 5 * time.Second
 


### PR DESCRIPTION
 - 56789: Default stats port (Previously 1936)
 - 56790: Default exporter port. Also the port used by operator to expose its own metrics.
 - 56791: HTTP port used with ACME HTTP challenge (Previously 56789)