### PR TITLE
Add a newline between crt & key.

### DIFF
--- a/hack/docker/haproxy/1.7.6/runit.sh
+++ b/hack/docker/haproxy/1.7.6/runit.sh
@@ -20,6 +20,7 @@ do
 	secret=${dir##*/}
 
 	cat $dir/tls.crt >  $CERT_DIR/$secret.pem
+	echo '\n' >>  $CERT_DIR/$secret.pem
 	cat $dir/tls.key >> $CERT_DIR/$secret.pem
 done
 


### PR DESCRIPTION
Manual testing shows HAProxy don't mind the extra newline.