### PR TITLE
Update aws-cert-manager.md

### DIFF
--- a/docs/user-guide/ingress/aws-cert-manager.md
+++ b/docs/user-guide/ingress/aws-cert-manager.md
@@ -4,8 +4,9 @@ add the following annotations to Ingress;
 ```yaml
   ingress.appscode.com/annotations-service: |
     {
-      "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "arn:aws:acm:..."
+      "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "arn:aws:acm:...",
       "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http",
+      "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "443"
     }
 ```
 


### PR DESCRIPTION
Clarify that the SSL listener should only be on 443.

https://github.com/appscode/voyager/issues/268