### PR TITLE
move RecognizeWellKnownRegions() to the beginning of newAWSCloud()

### DIFF
--- a/third_party/forked/cloudprovider/providers/aws/aws.go
+++ b/third_party/forked/cloudprovider/providers/aws/aws.go
@@ -489,6 +489,12 @@ func newAWSCloud(config io.Reader, awsServices Services) (*Cloud, error) {
 	// Log so that if we are building multiple Cloud objects, it is obvious!
 	glog.Infof("Building AWS cloudprovider")
 
+	// Register handler for ECR credentials
+	// Register regions, in particular for ECR credentials
+	once.Do(func() {
+		RecognizeWellKnownRegions()
+	})
+
 	metadata, err := awsServices.Metadata()
 	if err != nil {
 		return nil, fmt.Errorf("error creating AWS metadata client: %v", err)
@@ -569,12 +575,6 @@ func newAWSCloud(config io.Reader, awsServices Services) (*Cloud, error) {
 	} else {
 		glog.Infof("AWS cloud - no tag filtering")
 	}
-
-	// Register handler for ECR credentials
-	// Register regions, in particular for ECR credentials
-	once.Do(func() {
-		RecognizeWellKnownRegions()
-	})
 
 	return awsCloud, nil
 }

--- a/third_party/forked/cloudprovider/providers/aws/regions.go
+++ b/third_party/forked/cloudprovider/providers/aws/regions.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
-	awscredentialprovider "k8s.io/kubernetes/pkg/credentialprovider/aws"
 )
 
 // WellKnownRegions is the complete list of regions known to the AWS cloudprovider
@@ -74,7 +73,7 @@ func RecognizeRegion(region string) {
 
 	glog.V(4).Infof("found AWS region %q", region)
 
-	awscredentialprovider.RegisterCredentialsProvider(region)
+	// awscredentialprovider.RegisterCredentialsProvider(region)
 
 	awsRegions.Insert(region)
 }


### PR DESCRIPTION
fixes #281 

I hit this issue while trying to create an AppsCode Ingress using `NodePort` as well. Digging into the code, the tests are a little false-y in that an earlier test would call `newAWSCloud()` which would call `RecognizeWellKnownRegions()` and then any future tests would benefit from the well known regions getting loaded. This is obviously not the normal scenario when running the controller in a real world environment where the first invocation of `newAWSCloud()` would perform the `isValidRegion()` check prior to any regions being loaded.

I wasn't sure if the call to `awscredentialprovider.RegisterCredentialsProvider(region)` in `regions.go` was really necessary (i.e. being used) because it's the primary culprit for making sure a region is only loaded a single time due to calling `glog.Fatalf...` if a region is registered twice. If we could remove that, it could clean up the code a good bit I believe.