### PR TITLE
TLS Backend

### DIFF
--- a/api/annotations.go
+++ b/api/annotations.go
@@ -113,22 +113,28 @@ const (
 	DefaultsOption = EngressKey + "/default-option"
 
 	// Available Options
-	//   ssl :
-	//   Creates a TLS/SSL socket when connecting to this server in order to cipher/decipher the traffic
+	//   ssl:
+	//    Creates a TLS/SSL socket when connecting to this server in order to cipher/decipher the traffic
 	//
-	// verify [none|required] :
-	// Sets HAProxy‘s behavior regarding the certificated presented by the server:
+	//    if verify not set the following error may occurred
+	//    [/etc/haproxy/haproxy.cfg:49] verify is enabled by default but no CA file specified.
+	//    If you're running on a LAN where you're certain to trust the server's certificate,
+	//    please set an explicit 'verify none' statement on the 'server' line, or use
+	//    'ssl-server-verify none' in the global section to disable server-side verifications by default.
+	//
+	//   verify [none|required]:
+	//    Sets HAProxy‘s behavior regarding the certificated presented by the server:
 	//   none :
-	//   doesn’t verify the certificate of the server
+	//    doesn’t verify the certificate of the server
 	//
 	//   required (default value) :
-	//   TLS handshake is aborted if the validation of the certificate presented by the server returns an error.
+	//    TLS handshake is aborted if the validation of the certificate presented by the server returns an error.
 	//
-	// veryfyhost <hostname> :
-	// Sets a <hostname> to look for in the Subject and SubjectAlternateNames fields provided in the
-	// certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
+	//   veryfyhost <hostname>:
+	//    Sets a <hostname> to look for in the Subject and SubjectAlternateNames fields provided in the
+	//    certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
 	// ie.
-	// ingress.appscode.com/backend-tls: "ssl verify required"
+	// ingress.appscode.com/backend-tls: "ssl verify none"
 	BackendTLSOptions = EngressKey + "/backend-tls"
 )
 

--- a/api/annotations.go
+++ b/api/annotations.go
@@ -135,6 +135,9 @@ const (
 	//    certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
 	// ie.
 	// ingress.appscode.com/backend-tls: "ssl verify none"
+	//
+	// If this annotation is not set HAProxy will connect to backend as http,
+	// This value should not be set if the backend do not support https resolution.
 	BackendTLSOptions = EngressKey + "/backend-tls"
 )
 

--- a/api/annotations.go
+++ b/api/annotations.go
@@ -110,7 +110,7 @@ const (
 	//   option dontlognull
 	//   no option clitcpka
 	//
-	DefaultsOption = EngressKey + "/default-option"
+	DefaultsOption = EngressKey + "/" + "default-option"
 
 	// Available Options
 	//   ssl:

--- a/api/annotations.go
+++ b/api/annotations.go
@@ -110,7 +110,26 @@ const (
 	//   option dontlognull
 	//   no option clitcpka
 	//
-	DefaultsOption = EngressKey + "/" + "default-option"
+	DefaultsOption = EngressKey + "/default-option"
+
+	// Available Options
+	//   ssl :
+	//   Creates a TLS/SSL socket when connecting to this server in order to cipher/decipher the traffic
+	//
+	// verify [none|required] :
+	// Sets HAProxy‘s behavior regarding the certificated presented by the server:
+	//   none :
+	//   doesn’t verify the certificate of the server
+	//
+	//   required (default value) :
+	//   TLS handshake is aborted if the validation of the certificate presented by the server returns an error.
+	//
+	// veryfyhost <hostname> :
+	// Sets a <hostname> to look for in the Subject and SubjectAlternateNames fields provided in the
+	// certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
+	// ie.
+	// ingress.appscode.com/backend-tls: "ssl verify required"
+	BackendTLSOptions = EngressKey + "/backend-tls"
 )
 
 func (r Ingress) OffshootName() string {

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -150,14 +150,14 @@ backend {{ .DefaultBackend.Name }}
 	{{- range $e := .DefaultBackend.Endpoints }}
 	{{- if $e.ExternalName }}
 	{{- if $e.UseDNSResolver }}
-	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}}
+	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{- else if not $.DefaultBackend.BackendRules }}
 	acl https ssl_fc
 	http-request redirect location https://{{$e.ExternalName}}:{{ $e.Port }} code 301 if https
 	http-request redirect location http://{{$e.ExternalName}}:{{ $e.Port }} code 301 unless https
 	{{ end -}}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $.Sticky }} cookie {{ $e.Name }}{{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $.Sticky }} cookie {{ $e.Name }}{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{ end -}}
 	{{ end -}}
 `))
@@ -207,12 +207,12 @@ backend {{ $path.Backend.Name }}
 	{{- range $e := $path.Backend.Endpoints }}
 	{{- if $e.ExternalName }}
 	{{- if $e.UseDNSResolver }}
-	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}}
+	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{- else if not $path.Backend.BackendRules }}
 	http-request redirect location {{ if $.UsesSSL }}https://{{ else }}http://{{ end }}{{$e.ExternalName}}:{{ $e.Port }} code 301
 	{{- end }}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end -}} {{ if $.Sticky }} cookie {{ $e.Name }} {{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end -}} {{ if $.Sticky }} cookie {{ $e.Name }} {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{ end -}}
 	{{ end }}
 {{ end -}}
@@ -240,9 +240,9 @@ backend {{ .Backend.Name }}
 
 	{{- range $e := .Backend.Endpoints }}
 	{{- if $e.ExternalName }}
-	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check{{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4{{ end -}}
+	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check{{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{ end -}}
 	{{ end -}}
 `))

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -2,10 +2,10 @@ package haproxy
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"text/template"
 
-	"github.com/appscode/log"
 	"github.com/appscode/voyager/api"
 	"github.com/stretchr/testify/assert"
 )
@@ -111,7 +111,7 @@ func TestTemplate(t *testing.T) {
 							RewriteRules: []string{"first rule", "second rule"},
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323"},
-								{Name: "first", IP: "10.244.2.2", Port: "2324", ExternalName: "name", DNSResolver: "one", UseDNSResolver: true, CheckHealth: true},
+								{Name: "first", IP: "10.244.2.2", Port: "2324", ExternalName: "name", DNSResolver: "one", UseDNSResolver: true, CheckHealth: true, TLSOption: "ssl verify required"},
 							},
 						},
 					},
@@ -133,6 +133,27 @@ func TestTemplate(t *testing.T) {
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true},
 								{Name: "first", IP: "10.244.2.2", Port: "2324"},
+							},
+						},
+					},
+				},
+			},
+			{
+				SharedInfo:   &SharedInfo{Sticky: true},
+				FrontendName: "three",
+				Port:         9334,
+				UsesSSL:      true,
+				Paths: []*HTTPPath{
+					{
+						Path: "/kool",
+						Backend: Backend{
+							Name:         "kool",
+							BackendRules: []string{"first rule", "second rule"},
+							RewriteRules: []string{"first rule", "second rule"},
+							HeaderRules:  []string{"firstName value", "secondName value"},
+							Endpoints: []*Endpoint{
+								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify required"},
+								{Name: "first", IP: "10.244.2.2", Port: "2324", TLSOption: "ssl verify none"},
 							},
 						},
 					},
@@ -196,9 +217,23 @@ func TestTemplate(t *testing.T) {
 					},
 				},
 			},
+			{
+				SharedInfo:   si,
+				FrontendName: "rick-castle",
+				ALPNOptions:  "alpn h2options",
+				Host:         "hello.ok.domain",
+				Port:         "4445",
+				Backend: Backend{
+					Name: "kate-becket",
+					Endpoints: []*Endpoint{
+						{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify none"},
+						{Name: "first", IP: "10.244.2.2", Port: "2324", ExternalName: "ext-name", TLSOption: "ssl verify required"},
+					},
+				},
+			},
 		},
 	}
 	config, err := RenderConfig(testParsedConfig)
 	assert.Nil(t, err)
-	log.Debugln(config)
+	fmt.Println(config)
 }

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -97,4 +97,21 @@ type Endpoint struct {
 	UseDNSResolver bool
 	DNSResolver    string
 	CheckHealth    bool
+
+	// Available Options
+	//   ssl :
+	//   Creates a TLS/SSL socket when connecting to this server in order to cipher/decipher the traffic
+	//
+	// verify [none|required] :
+	// Sets HAProxy‘s behavior regarding the certificated presented by the server:
+	//   none :
+	//   doesn’t verify the certificate of the server
+	//
+	//   required (default value) :
+	//   TLS handshake is aborted if the validation of the certificate presented by the server returns an error.
+	//
+	// veryfyhost <hostname> :
+	// Sets a <hostname> to look for in the Subject and SubjectAlternateNames fields provided in the
+	// certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
+	TLSOption string
 }

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -98,20 +98,5 @@ type Endpoint struct {
 	DNSResolver    string
 	CheckHealth    bool
 
-	// Available Options
-	//   ssl :
-	//   Creates a TLS/SSL socket when connecting to this server in order to cipher/decipher the traffic
-	//
-	// verify [none|required] :
-	// Sets HAProxy‘s behavior regarding the certificated presented by the server:
-	//   none :
-	//   doesn’t verify the certificate of the server
-	//
-	//   required (default value) :
-	//   TLS handshake is aborted if the validation of the certificate presented by the server returns an error.
-	//
-	// veryfyhost <hostname> :
-	// Sets a <hostname> to look for in the Subject and SubjectAlternateNames fields provided in the
-	// certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
 	TLSOption string
 }

--- a/pkg/ingress/parser.go
+++ b/pkg/ingress/parser.go
@@ -132,6 +132,11 @@ func (c *controller) getEndpoints(s *apiv1.Service, servicePort *apiv1.ServicePo
 							}
 						}
 					}
+
+					if s.Annotations != nil {
+						ep.TLSOption = s.Annotations[api.BackendTLSOptions]
+					}
+
 					eps = append(eps, ep)
 				}
 			}

--- a/test/e2e/ingress_tls_backend.go
+++ b/test/e2e/ingress_tls_backend.go
@@ -1,0 +1,83 @@
+package e2e
+
+import (
+	"net/http"
+
+	"github.com/appscode/voyager/api"
+	"github.com/appscode/voyager/test/framework"
+	"github.com/appscode/voyager/test/test-server/testserverclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("IngressBackendTLS", func() {
+	var (
+		f   *framework.Invocation
+		ing *api.Ingress
+	)
+
+	BeforeEach(func() {
+		f = root.Invoke()
+		ing = f.Ingress.GetSkeleton()
+		f.Ingress.SetSkeletonRule(ing)
+	})
+
+	JustBeforeEach(func() {
+		By("Creating ingress with name " + ing.GetName())
+		err := f.Ingress.Create(ing)
+		Expect(err).NotTo(HaveOccurred())
+
+		f.Ingress.EventuallyStarted(ing).Should(BeTrue())
+
+		By("Checking generated resource")
+		Expect(f.Ingress.IsExistsEventually(ing)).Should(BeTrue())
+	})
+
+	AfterEach(func() {
+		if root.Config.Cleanup {
+			f.Ingress.Delete(ing)
+		}
+	})
+
+	Describe("Backend have ssl", func() {
+		BeforeEach(func() {
+			ing.Spec = api.IngressSpec{
+				Rules: []api.IngressRule{
+					{
+						IngressRuleValue: api.IngressRuleValue{
+							HTTP: &api.HTTPIngressRuleValue{
+								Paths: []api.HTTPIngressPath{
+									{
+										Path: "/testpath",
+										Backend: api.HTTPIngressBackend{
+											IngressBackend: api.IngressBackend{
+												ServiceName: f.Ingress.TestServerHTTPSName(),
+												ServicePort: intstr.FromInt(443),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("Should response HTTP", func() {
+			By("Getting HTTP endpoints")
+			eps, err := f.Ingress.GetHTTPEndpoints(ing)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(eps)).Should(BeNumerically(">=", 1))
+
+			err = f.Ingress.DoHTTP(framework.MaxRetry, "", ing, eps, "GET", "/testpath/ok", func(r *testserverclient.Response) bool {
+				return Expect(r.Status).Should(Equal(http.StatusOK)) &&
+					Expect(r.Method).Should(Equal("GET")) &&
+					Expect(r.Path).Should(Equal("/testpath/ok")) &&
+					Expect(r.ServerPort).Should(Equal(":6443"))
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -74,3 +74,7 @@ func (f *Framework) Invoke() *Invocation {
 		Ingress:        &ingressInvocation{rootInvocation: r},
 	}
 }
+
+func (f *rootInvocation) App() string {
+	return f.app
+}

--- a/test/framework/ingress_suite.go
+++ b/test/framework/ingress_suite.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	testServerImage = "appscode/test-server:1.4"
+	testServerImage = "appscode/test-server:2.0"
 )
 
 var (
-	testServerResourceName = "e2e-test-server-" + rand.Characters(5)
+	testServerResourceName      = "e2e-test-server-" + rand.Characters(5)
+	testServerHTTpsResourceName = "e2e-test-server-https" + rand.Characters(5)
 )
 
 func (i *ingressInvocation) Setup() error {
@@ -35,6 +36,7 @@ func (i *ingressInvocation) Setup() error {
 func (i *ingressInvocation) Teardown() {
 	if i.Config.Cleanup {
 		i.KubeClient.CoreV1().Services(i.Namespace()).Delete(testServerResourceName, &metav1.DeleteOptions{})
+		i.KubeClient.CoreV1().Services(i.Namespace()).Delete(testServerHTTpsResourceName, &metav1.DeleteOptions{})
 		rc, err := i.KubeClient.CoreV1().ReplicationControllers(i.Namespace()).Get(testServerResourceName, metav1.GetOptions{})
 		if err == nil {
 			rc.Spec.Replicas = types.Int32P(0)
@@ -54,6 +56,10 @@ func (i *ingressInvocation) Teardown() {
 
 func (i *ingressInvocation) TestServerName() string {
 	return testServerResourceName
+}
+
+func (i *ingressInvocation) TestServerHTTPSName() string {
+	return testServerHTTpsResourceName
 }
 
 func (i *ingressInvocation) Create(ing *api.Ingress) error {

--- a/test/framework/ingress_util.go
+++ b/test/framework/ingress_util.go
@@ -149,6 +149,41 @@ func (i *ingressInvocation) createTestServerService() error {
 			},
 		},
 	})
+	if err != nil {
+		return err
+	}
+
+	_, err = i.KubeClient.CoreV1().Services(i.Namespace()).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServerHTTpsResourceName,
+			Namespace: i.Namespace(),
+			Labels: map[string]string{
+				"app": i.app,
+			},
+			Annotations: map[string]string{
+				"ingress.appscode.com/backend-tls": "ssl verify none",
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Name:       "http-1",
+					Port:       443,
+					TargetPort: intstr.FromInt(6443),
+					Protocol:   "TCP",
+				},
+				{
+					Name:       "http-2",
+					Port:       3443,
+					TargetPort: intstr.FromInt(3443),
+					Protocol:   "TCP",
+				},
+			},
+			Selector: map[string]string{
+				"app": i.app,
+			},
+		},
+	})
 	return err
 }
 
@@ -180,6 +215,14 @@ func (i *ingressInvocation) testServerPodSpec() apiv1.PodSpec {
 					{
 						Name:          "http-3",
 						ContainerPort: 9090,
+					},
+					{
+						Name:          "https-1",
+						ContainerPort: 6443,
+					},
+					{
+						Name:          "https-2",
+						ContainerPort: 3443,
 					},
 					{
 						Name:          "tcp-1",

--- a/test/test-server/gen_cert.go
+++ b/test/test-server/gen_cert.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+var (
+	validFrom = flag.String("start-date", "", "Creation date formatted as Jan 1 15:04:05 2011")
+	validFor  = flag.Duration("duration", 365*24*time.Hour, "Duration that certificate is valid for")
+	isCA      = flag.Bool("ca", false, "whether this cert should be its own Certificate Authority")
+	rsaBits   = flag.Int("rsa-bits", 2048, "Size of RSA key to generate. Ignored if --ecdsa-curve is set")
+)
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to marshal ECDSA private key: %v", err)
+			os.Exit(2)
+		}
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	default:
+		return nil
+	}
+}
+
+func GenCert(host string) {
+	if len(host) == 0 {
+		log.Fatalf("Missing required --host parameter")
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, *rsaBits)
+	if err != nil {
+		log.Fatalf("failed to generate private key: %s", err)
+	}
+
+	var notBefore time.Time
+	if len(*validFrom) == 0 {
+		notBefore = time.Now()
+	} else {
+		notBefore, err = time.Parse("Jan 2 15:04:05 2006", *validFrom)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to parse creation date: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	notAfter := notBefore.Add(*validFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	if *isCA {
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	certOut, err := os.Create("cert.pem")
+	if err != nil {
+		log.Fatalf("failed to open cert.pem for writing: %s", err)
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+	log.Print("written cert.pem\n")
+
+	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		log.Print("failed to open key.pem for writing:", err)
+		return
+	}
+	pem.Encode(keyOut, pemBlockForKey(priv))
+	keyOut.Close()
+	log.Print("written key.pem\n")
+}

--- a/test/test-server/setup.sh
+++ b/test/test-server/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=1.4
+VERSION=2.0
 
 build() {
     rm -rf dist/*


### PR DESCRIPTION
Setting `ingress.appscode.com/backend-tls` annotation in the service will set tls from haproxy to backend.
```
 Available Options
   ssl:
	Creates a TLS/SSL socket when connecting to this server in order to cipher/decipher the traffic

	if verify not set the following error may occurred
	[/etc/haproxy/haproxy.cfg:49] verify is enabled by default but no CA file specified.
	If you're running on a LAN where you're certain to trust the server's certificate,
	please set an explicit 'verify none' statement on the 'server' line, or use
	'ssl-server-verify none' in the global section to disable server-side verifications by default.

   verify [none|required]:
	Sets HAProxy‘s behavior regarding the certificated presented by the server:
   none :
	doesn’t verify the certificate of the server

   required (default value) :
	TLS handshake is aborted if the validation of the certificate presented by the server returns an error.

   veryfyhost <hostname>:
	Sets a <hostname> to look for in the Subject and SubjectAlternateNames fields provided in the
	certificate sent by the server. If <hostname> can’t be found, then the TLS handshake is aborted.
 ie.
 ingress.appscode.com/backend-tls: "ssl verify none"
```