### PR TITLE
Fix Host:Port Matching issue.

### DIFF
--- a/api/validator_test.go
+++ b/api/validator_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -178,7 +178,10 @@ frontend {{ .FrontendName }}
 	option forwardfor
 
 	{{- range $path := .Paths }}
+	{{ if  or (or (eq $.Port 80) (eq $.Port 443)) (or (eq $.NodePort 80) (eq $.NodePort 443)) }}
 	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ end }}
+	{{- end }}
+	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ if $.NodePort }}:{{ $.NodePort }}{{ else }}:{{ $.Port }}{{ end }}{{ end }}
 	{{ if $path.Path }}acl url_acl_{{ $path.Backend.Name }} path_beg {{ $path.Path }}{{ end }}
 	use_backend {{ $path.Backend.Name }} {{ if or $path.Host $path.Path }}if {{ end }}{{ if $path.Host }}host_acl_{{ $path.Backend.Name }}{{ end }}{{ if $path.Path }} url_acl_{{ $path.Backend.Name }}{{ end -}}
 	{{ end }}

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -178,7 +178,7 @@ frontend {{ .FrontendName }}
 	option forwardfor
 
 	{{- range $path := .Paths }}
-	{{ if  or (eq $.Port 80) (eq $.Port 443) }}
+	{{ if  and (or (eq $.Port 80) (eq $.Port 443)) (not $.NodePort) }}
 	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ end }}
 	{{- end }}
 	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ if $.NodePort }}:{{ $.NodePort }}{{ else }}:{{ $.Port }}{{ end }}{{ end }}

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -178,7 +178,7 @@ frontend {{ .FrontendName }}
 	option forwardfor
 
 	{{- range $path := .Paths }}
-	{{ if  or (or (eq $.Port 80) (eq $.Port 443)) (or (eq $.NodePort 80) (eq $.NodePort 443)) }}
+	{{ if  or (eq $.Port 80) (eq $.Port 443) }}
 	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ end }}
 	{{- end }}
 	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ if $.NodePort }}:{{ $.NodePort }}{{ else }}:{{ $.Port }}{{ end }}{{ end }}

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -171,7 +171,7 @@ func TestTemplate(t *testing.T) {
 						Host: "ex.appscode.dev",
 						Path: "/yara",
 						Backend: Backend{
-							Name:         "yara",
+							Name: "yara",
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify required"},
 							},
@@ -189,7 +189,7 @@ func TestTemplate(t *testing.T) {
 						Host: "ex.appscode.dev",
 						Path: "/yara",
 						Backend: Backend{
-							Name:         "yara",
+							Name: "yara",
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify required"},
 							},

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -105,6 +105,7 @@ func TestTemplate(t *testing.T) {
 						},
 					},
 					{
+						Host: "test.appscode.dev",
 						Path: "/rebeka",
 						Backend: Backend{
 							Name:         "rebecka",
@@ -154,6 +155,43 @@ func TestTemplate(t *testing.T) {
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify required"},
 								{Name: "first", IP: "10.244.2.2", Port: "2324", TLSOption: "ssl verify none"},
+							},
+						},
+					},
+				},
+			},
+			{
+				SharedInfo:   &SharedInfo{Sticky: true},
+				FrontendName: "four",
+				Port:         8334,
+				NodePort:     32000,
+				UsesSSL:      true,
+				Paths: []*HTTPPath{
+					{
+						Host: "ex.appscode.dev",
+						Path: "/yara",
+						Backend: Backend{
+							Name:         "yara",
+							Endpoints: []*Endpoint{
+								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify required"},
+							},
+						},
+					},
+				},
+			},
+			{
+				SharedInfo:   &SharedInfo{Sticky: true},
+				FrontendName: "five",
+				Port:         80,
+				UsesSSL:      true,
+				Paths: []*HTTPPath{
+					{
+						Host: "ex.appscode.dev",
+						Path: "/yara",
+						Backend: Backend{
+							Name:         "yara",
+							Endpoints: []*Endpoint{
+								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true, TLSOption: "ssl verify required"},
 							},
 						},
 					},

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -36,7 +36,7 @@ type HTTPService struct {
 
 	FrontendName string
 	Port         int
-	NodePort     int
+	NodePort     int32
 	UsesSSL      bool
 	Paths        []*HTTPPath
 }

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -36,6 +36,7 @@ type HTTPService struct {
 
 	FrontendName string
 	Port         int
+	NodePort     int
 	UsesSSL      bool
 	Paths        []*HTTPPath
 }

--- a/pkg/ingress/parser.go
+++ b/pkg/ingress/parser.go
@@ -225,8 +225,9 @@ func (c *controller) generateConfig() error {
 	td.TCPService = make([]*haproxy.TCPService, 0)
 
 	type httpKey struct {
-		Port    int
-		UsesSSL bool
+		Port     int
+		NodePort int
+		UsesSSL  bool
 	}
 	httpServices := make(map[httpKey][]*haproxy.HTTPPath)
 	for _, rule := range c.Ingress.Spec.Rules {
@@ -268,6 +269,7 @@ func (c *controller) generateConfig() error {
 					key.Port = 80
 				}
 			}
+			key.NodePort = rule.HTTP.NodePort.IntValue()
 
 			if v, ok := httpServices[key]; ok {
 				httpServices[key] = append(v, httpPaths...)
@@ -306,6 +308,7 @@ func (c *controller) generateConfig() error {
 			SharedInfo:   si,
 			FrontendName: fmt.Sprintf("http-%d", key.Port),
 			Port:         key.Port,
+			NodePort:     key.NodePort,
 			UsesSSL:      key.UsesSSL,
 			Paths:        value,
 		})

--- a/test/e2e/ingress_nodeport.go
+++ b/test/e2e/ingress_nodeport.go
@@ -1,0 +1,64 @@
+package e2e
+
+import (
+	"net/http"
+
+	"github.com/appscode/voyager/api"
+	"github.com/appscode/voyager/test/framework"
+	"github.com/appscode/voyager/test/test-server/testserverclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("IngressNodePort", func() {
+	var (
+		f   *framework.Invocation
+		ing *api.Ingress
+	)
+
+	BeforeEach(func() {
+		f = root.Invoke()
+		ing = f.Ingress.GetSkeleton()
+		f.Ingress.SetSkeletonRule(ing)
+	})
+
+	JustBeforeEach(func() {
+		By("Creating ingress with name " + ing.GetName())
+		err := f.Ingress.Create(ing)
+		Expect(err).NotTo(HaveOccurred())
+
+		f.Ingress.EventuallyStarted(ing).Should(BeTrue())
+
+		By("Checking generated resource")
+		Expect(f.Ingress.IsExistsEventually(ing)).Should(BeTrue())
+	})
+
+	AfterEach(func() {
+		if root.Config.Cleanup {
+			f.Ingress.Delete(ing)
+		}
+	})
+
+	Describe("Create", func() {
+		BeforeEach(func() {
+			ing.Annotations[api.LBType] = api.LBTypeNodePort
+			ing.Spec.Rules[0].Host = "test.appscode.dev"
+			ing.Spec.Rules[0].HTTP.NodePort = intstr.FromInt(32368)
+		})
+
+		It("Should response HTTP", func() {
+			By("Getting HTTP endpoints")
+			eps, err := f.Ingress.GetHTTPEndpoints(ing)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(eps)).Should(BeNumerically(">=", 1))
+
+			err = f.Ingress.DoHTTP(framework.MaxRetry, "test.appscode.dev:32368", ing, eps, "GET", "/testpath/ok", func(r *testserverclient.Response) bool {
+				return Expect(r.Status).Should(Equal(http.StatusOK)) &&
+					Expect(r.Method).Should(Equal("GET")) &&
+					Expect(r.Path).Should(Equal("/testpath/ok"))
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
ACLs sharing the same name
It is possible to use the same <aclname> for many ACLs, even if they don’t have the same matching criterion A logical OR applies between all of them
https://www.haproxy.com/doc/aloha/7.0/haproxy/acls.html#acls-sharing-the-same-name