### PR TITLE
Fix NPE

### DIFF
--- a/api/validator.go
+++ b/api/validator.go
@@ -63,10 +63,10 @@ func (r Ingress) IsValid(cloudProvider string) error {
 			var a *address
 			if ea, found := addrs[podPort]; found {
 				if ea.Protocol == "tcp" {
-					return fmt.Errorf("spec.rule[%d].http is reusing port %d, also used in spec.rule[%d]", ri, a.PodPort, ea.FirstRuleIndex)
+					return fmt.Errorf("spec.rule[%d].http is reusing port %d, also used in spec.rule[%d]", ri, ea.PodPort, ea.FirstRuleIndex)
 				}
 				if nodePort != ea.NodePort {
-					return fmt.Errorf("spec.rule[%d].http.nodePort %d does not match with nodePort %d", ri, a.NodePort, ea.NodePort)
+					return fmt.Errorf("spec.rule[%d].http.nodePort %d does not match with nodePort %d", ri, ea.NodePort, ea.NodePort)
 				} else {
 					nodePorts[nodePort] = ri
 				}
@@ -74,7 +74,7 @@ func (r Ingress) IsValid(cloudProvider string) error {
 			} else {
 				if nodePort > 0 {
 					if ei, found := nodePorts[nodePort]; found {
-						return fmt.Errorf("spec.rule[%d].http is reusing nodePort %d for addr %s, also used in spec.rule[%d]", ri, a.NodePort, a, ei)
+						return fmt.Errorf("spec.rule[%d].http is reusing nodePort %d for addr %s, also used in spec.rule[%d]", ri, nodePort, a, ei)
 					} else {
 						nodePorts[nodePort] = ri
 					}


### PR DESCRIPTION
```
0907 13:26:56.912725      35 logs.go:19] FLAG: --address=":56790"
I0907 13:26:56.912866      35 logs.go:19] FLAG: --alsologtostderr="false"
I0907 13:26:56.912893      35 logs.go:19] FLAG: --analytics="true"
I0907 13:26:56.912906      35 logs.go:19] FLAG: --cloud-config=""
I0907 13:26:56.912917      35 logs.go:19] FLAG: --cloud-provider=""
I0907 13:26:56.912926      35 logs.go:19] FLAG: --custom-templates=""
I0907 13:26:56.912951      35 logs.go:19] FLAG: --haproxy-image="artifactrepo:9096/google-containers/appscode/haproxy:1.7.6-3.1.0"
I0907 13:26:56.912966      35 logs.go:19] FLAG: --haproxy.server-metric-fields="2,3,4,5,6,7,8,9,13,14,15,16,17,18,21,24,33,35,38,39,40,41,42,43,44"
I0907 13:26:56.912982      35 logs.go:19] FLAG: --haproxy.timeout="5s"
I0907 13:26:56.912994      35 logs.go:19] FLAG: --help="false"
I0907 13:26:56.913019      35 logs.go:19] FLAG: --http-challenge-port="56791"
I0907 13:26:56.913030      35 logs.go:19] FLAG: --ingress-class=""
I0907 13:26:56.913051      35 logs.go:19] FLAG: --kubeconfig=""
I0907 13:26:56.913069      35 logs.go:19] FLAG: --log_backtrace_at=":0"
I0907 13:26:56.913081      35 logs.go:19] FLAG: --log_dir=""
I0907 13:26:56.913091      35 logs.go:19] FLAG: --logtostderr="true"
I0907 13:26:56.913102      35 logs.go:19] FLAG: --master=""
I0907 13:26:56.913113      35 logs.go:19] FLAG: --operator-service="voyager-operator"
I0907 13:26:56.913127      35 logs.go:19] FLAG: --rbac="true"
I0907 13:26:56.913149      35 logs.go:19] FLAG: --resync-period="5m0s"
I0907 13:26:56.913160      35 logs.go:19] FLAG: --stderrthreshold="2"
I0907 13:26:56.913194      35 logs.go:19] FLAG: --v="3"
I0907 13:26:56.913216      35 logs.go:19] FLAG: --vmodule=""
W0907 13:27:26.914266      35 client_config.go:517] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0907 13:27:26.920713      35 run.go:112] Starting Voyager operator...
I0907 13:27:26.920849      35 operator.go:56] Ensuring TPR registration
I0907 13:27:26.979545      35 validator.go:51] Checking ingress apis-ingress@default
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xebd814]

goroutine 1 [running]:
github.com/appscode/voyager/api.Ingress.IsValid(0xc4202b7a98, 0x7, 0xc4205c3920, 0x1c, 0xc4202b7d10, 0xc, 0x0, 0x0, 0xc4202b7d20, 0x7, ...)
    /go/src/github.com/appscode/voyager/api/validator.go:77 +0x2504
github.com/appscode/voyager/pkg/operator.(*Operator).ValidateIngress(0xc4205ce000, 0x0, 0x0)
    /go/src/github.com/appscode/voyager/pkg/operator/validator.go:52 +0xcf4
github.com/appscode/voyager/pkg/cmds.run()
    /go/src/github.com/appscode/voyager/pkg/cmds/run.go:120 +0x460
github.com/appscode/voyager/pkg/cmds.NewCmdRun.func1(0xc420204480, 0xc4200559e0, 0x0, 0x6)
    /go/src/github.com/appscode/voyager/pkg/cmds/run.go:57 +0x20
github.com/appscode/voyager/vendor/github.com/spf13/cobra.(*Command).execute(0xc420204480, 0xc420055920, 0x6, 0x6, 0xc420204480, 0xc420055920)
```