### PR TITLE
Implement Basic Auth for HTTP Ingresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can find the generated HAProxy Configuration [here](hack/example/haproxy_gen
   - [Backend TLS](/docs/user-guide/ingress/backend-tls.md)
   - [Configure Options](/docs/user-guide/ingress/configure-options.md)
   - [Using Custom HAProxy Templates](/docs/user-guide/ingress/custom-templates.md)
+  - [Configure Basic Auth for HTTP Backends](docs/user-guide/ingress/basic-auth.md)
 
 ### Comparison with Kubernetes
 | Feauture | [Kube Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) | AppsCode Ingress |

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ To disable stats collection, run the operator with the flag** `--analytics=false
 ## Acknowledgement
  - docker-library/haproxy https://github.com/docker-library/haproxy
  - kubernetes/contrib https://github.com/kubernetes/contrib/tree/master/service-loadbalancer
+ - kubernetes/ingress https://github.com/kubernetes/ingress
  - xenolf/lego https://github.com/appscode/lego
  - kelseyhightower/kube-cert-manager https://github.com/kelseyhightower/kube-cert-manager
  - PalmStoneGames/kube-cert-manager https://github.com/PalmStoneGames/kube-cert-manager
  - [Kubernetes cloudprovider implementation](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider)
- - [HAProxy Ingress](https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy)
 
 ## Support
 If you have any questions, you can reach out to us.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ To disable stats collection, run the operator with the flag** `--analytics=false
  - xenolf/lego https://github.com/appscode/lego
  - kelseyhightower/kube-cert-manager https://github.com/kelseyhightower/kube-cert-manager
  - PalmStoneGames/kube-cert-manager https://github.com/PalmStoneGames/kube-cert-manager
- - [Kubernetes cloudprovider implementation](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider) 
+ - [Kubernetes cloudprovider implementation](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider)
+ - [HAProxy Ingress](https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy)
 
 ## Support
 If you have any questions, you can reach out to us.

--- a/api/annotations.go
+++ b/api/annotations.go
@@ -161,6 +161,24 @@ const (
 	// If applied to Service and Ingress do not have this annotation only
 	// connection to that backend service will be sticky.
 	StickySession = EngressKey + "/" + "sticky-session"
+
+	// Basic Auth; Follows haproxy ingress controller standard
+	// https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy
+	// HAProxy Ingress read user and password from auth file stored on secrets, one
+	// user and password per line.
+	// Each line of the auth file should have:
+	// user and insecure password separated with a pair of colons: <username>::<plain-text-passwd>; or
+	// user and an encrypted password separated with colons: <username>:<encrypted-passwd>
+	// Secret name, realm and type are configured with annotations in the ingress
+	// Auth can only be applied to HTTP backends.
+	// Only supported type is basic
+	AuthType = "ingress.kubernetes.io/auth-type"
+
+	// an optional string with authentication realm
+	AuthRealm = "ingress.kubernetes.io/auth-realm"
+
+	// name of the secret
+	AuthSecret = "ingress.kubernetes.io/auth-secret"
 )
 
 func (r Ingress) OffshootName() string {
@@ -412,6 +430,32 @@ func (r Ingress) CertificateSpec() (*Certificate, bool) {
 		return newCertificate, true
 	}
 	return nil, false
+}
+
+func (r Ingress) AuthEnabled() bool {
+	if r.Annotations == nil {
+		return false
+	}
+
+	// Check auth type is basic; other auth mode is not supported
+	if val := getString(r.Annotations, AuthType); val != "basic" {
+		return false
+	}
+
+	// Check secret name is not empty
+	if val := getString(r.Annotations, AuthSecret); len(val) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (r Ingress) AuthRealm() string {
+	return getString(r.Annotations, AuthRealm)
+}
+
+func (r Ingress) AuthSecretName() string {
+	return getString(r.Annotations, AuthSecret)
 }
 
 // ref: https://github.com/kubernetes/kubernetes/blob/078238a461a0872a8eacb887fbb3d0085714604c/staging/src/k8s.io/apiserver/pkg/apis/example/v1/types.go#L134

--- a/api/annotations.go
+++ b/api/annotations.go
@@ -162,7 +162,7 @@ const (
 	// connection to that backend service will be sticky.
 	StickySession = EngressKey + "/" + "sticky-session"
 
-	// Basic Auth; Follows haproxy ingress controller standard
+	// Basic Auth: Follows ingress controller standard
 	// https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy
 	// HAProxy Ingress read user and password from auth file stored on secrets, one
 	// user and password per line.
@@ -177,7 +177,7 @@ const (
 	// an optional string with authentication realm
 	AuthRealm = "ingress.kubernetes.io/auth-realm"
 
-	// name of the secret
+	// name of the auth secret
 	AuthSecret = "ingress.kubernetes.io/auth-secret"
 )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ You can find the generated HAProxy Configuration [here](hack/example/haproxy_gen
   - [Set NodePort](docs/user-guide/ingress/node-port.md)
   - [Backend TLS](docs/user-guide/ingress/backend-tls.md)
   - [Configure Options](docs/user-guide/ingress/configure-options.md)
+  - [Configure Basic Auth for HTTP Backends](docs/user-guide/ingress/basic-auth.md)
 
 ### Comparison with Kubernetes
 | Feauture | [Kube Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) | AppsCode Ingress |

--- a/docs/user-guide/ingress/README.md
+++ b/docs/user-guide/ingress/README.md
@@ -41,6 +41,7 @@ hosting. This plugin also support configurable application ports with all the fe
   - [Backend TLS](/docs/user-guide/ingress/backend-tls.md)
   - [Configure Options](/docs/user-guide/ingress/configure-options.md)
   - [Using Custom HAProxy Templates](/docs/user-guide/ingress/custom-templates.md)
+  - [Configure Basic Auth for HTTP Backends](docs/user-guide/ingress/basic-auth.md)
 
 ### Comparison with Kubernetes
 | Feauture | Kube Ingress | AppsCode Ingress |

--- a/docs/user-guide/ingress/basic-auth.md
+++ b/docs/user-guide/ingress/basic-auth.md
@@ -6,7 +6,7 @@ Voyager Ingress controller.
 
 ## Using Basic Authentication
 
-HAProxy Ingress read user and password from `auth` file stored on secrets, one user
+Voyager Ingress read user and password from files stored on secrets, one user
 and password per line. Secret name, realm and type are configured with annotations
 in the ingress resource:
 
@@ -94,3 +94,6 @@ Content-Type: text/plain; charset=utf-8
 ```
 
 Using `jane:guest` user/passwd should have the same output.
+
+## Acknowledgement
+  - [HAProxy Ingress](https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy)

--- a/docs/user-guide/ingress/basic-auth.md
+++ b/docs/user-guide/ingress/basic-auth.md
@@ -1,4 +1,4 @@
-# Voyager Ingress Basic Authentication
+# Basic Authentication
 
 This example demonstrates how to configure
 [Basic Authentication](https://tools.ietf.org/html/rfc2617) on
@@ -96,4 +96,4 @@ Content-Type: text/plain; charset=utf-8
 Using `jane:guest` user/passwd should have the same output.
 
 ## Acknowledgement
-  - [HAProxy Ingress](https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy)
+  - This document has been adapted from [/kubernetes/ingress](https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy) project.

--- a/docs/user-guide/ingress/basic-auth.md
+++ b/docs/user-guide/ingress/basic-auth.md
@@ -44,26 +44,25 @@ $ kubectl create secret generic mypasswd --from-file auth
 $ rm -fv auth
 ```
 
-Create an Ingress with Basic Auth Annotations
+Create an Ingress with Basic Auth annotations
 ```yaml
-  apiVersion: voyager.appscode.com/v1beta1
-  kind: Ingress
-  metadata:
-    annotations:
-      ingress.kubernetes.io/auth-type: basic
-      ingress.kubernetes.io/auth-realm: My Server
-      ingress.kubernetes.io/auth-secret: mypasswd
-    name: hello-basic-auth
-    namespace: default
-  spec:
-    rules:
-    - http:
-        paths:
-        - path: /testpath
-          backend:
-            serviceName: backend
-            servicePort: 80
-
+apiVersion: voyager.appscode.com/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/auth-type: basic
+    ingress.kubernetes.io/auth-realm: My Server
+    ingress.kubernetes.io/auth-secret: mypasswd
+  name: hello-basic-auth
+  namespace: default
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: test-server
+          servicePort: 80
 ```
 
 Test without user and password:

--- a/docs/user-guide/ingress/basic-auth.md
+++ b/docs/user-guide/ingress/basic-auth.md
@@ -1,0 +1,96 @@
+# Voyager Ingress Basic Authentication
+
+This example demonstrates how to configure
+[Basic Authentication](https://tools.ietf.org/html/rfc2617) on
+Voyager Ingress controller.
+
+## Using Basic Authentication
+
+HAProxy Ingress read user and password from `auth` file stored on secrets, one user
+and password per line. Secret name, realm and type are configured with annotations
+in the ingress resource:
+
+* `ingress.kubernetes.io/auth-type`: the only supported type is `basic`
+* `ingress.kubernetes.io/auth-realm`: an optional string with authentication realm
+* `ingress.kubernetes.io/auth-secret`: name of the secret
+
+Each line of the `auth` file should have:
+
+* user and insecure password separated with a pair of colons: `<username>::<plain-text-passwd>`; or
+* user and an encrypted password separated with colons: `<username>:<encrypted-passwd>`
+
+HAProxy evaluates encrypted passwords with
+[crypt](http://man7.org/linux/man-pages/man3/crypt.3.html) function. Use `mkpasswd` or
+`makepasswd` to create it. `mkpasswd` can be found on Alpine Linux container.
+
+## Configure
+
+Create a secret to our users:
+
+* `john` and password `admin` using insecure plain text password
+* `jane` and password `guest` using encrypted password
+
+```console
+$ mkpasswd -m des ## a short, des encryption, syntax from Busybox on Alpine Linux
+Password: (type 'guest' and press Enter)
+E5BrlrQ5IXYK2
+
+$ cat >auth <<EOF
+john::admin
+jane:E5BrlrQ5IXYK2
+EOF
+
+$ kubectl create secret generic mypasswd --from-file auth
+$ rm -fv auth
+```
+
+Create an Ingress with Basic Auth Annotations
+```yaml
+  apiVersion: voyager.appscode.com/v1beta1
+  kind: Ingress
+  metadata:
+    annotations:
+      ingress.kubernetes.io/auth-type: basic
+      ingress.kubernetes.io/auth-realm: My Server
+      ingress.kubernetes.io/auth-secret: mypasswd
+    name: hello-basic-auth
+    namespace: default
+  spec:
+    rules:
+    - http:
+        paths:
+        - path: /testpath
+          backend:
+            serviceName: backend
+            servicePort: 80
+
+```
+
+Test without user and password:
+
+```console
+$ curl -i ip:port
+HTTP/1.0 401 Unauthorized
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/html
+Authentication problem. Ignoring this.
+WWW-Authenticate: Basic realm="Realm returned"
+
+<html><body><h1>401 Unauthorized</h1>
+You need a valid user and password to access this content.
+</body></html>
+```
+
+Send a valid user:
+
+```console
+$ curl -i -u 'john:admin' ip:port
+HTTP/1.1 200 OK
+Date: Fri, 08 Sep 2017 09:31:43 GMT
+Content-Length: 0
+Content-Type: text/plain; charset=utf-8
+
+```
+
+Using `jane:guest` user/passwd should have the same output.

--- a/docs/user-guide/ingress/basic-auth.md
+++ b/docs/user-guide/ingress/basic-auth.md
@@ -16,11 +16,11 @@ in the ingress resource:
 
 Each line of the `auth` file should have:
 
-* user and insecure password separated with a pair of colons: `<username>::<plain-text-passwd>`; or
+* user and insecure password separated with a pair of colons: `<username>::<plain-text-password>`; or
 * user and an encrypted password separated with colons: `<username>:<encrypted-passwd>`
 
-HAProxy evaluates encrypted passwords with
-[crypt](http://man7.org/linux/man-pages/man3/crypt.3.html) function. Use `mkpasswd` or
+If passwords are provided in plain text, Voyager operator will encrypt them before rendering HAProxy configuration.
+HAProxy evaluates encrypted passwords with [crypt](http://man7.org/linux/man-pages/man3/crypt.3.html) function. Use `mkpasswd` or
 `makepasswd` to create it. `mkpasswd` can be found on Alpine Linux container.
 
 ## Configure

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b842d99c481fedf52f7f94c28c3d3148e62e991e8d27df8fe157b601e8cc2359
-updated: 2017-09-01T19:42:43.156354712-07:00
+hash: 1dff9acd5562bf75b535a77287853faf2d29ae1ce5abc4c5a08b2d09a3cf424b
+updated: 2017-09-09T12:16:05.803768329-07:00
 imports:
 - name: cloud.google.com/go
   version: fe3d41e1ecb2ce36ad3a979037c9b9a2b726226f
@@ -251,7 +251,7 @@ imports:
 - name: github.com/orcaman/concurrent-map
   version: 2ae17bc4c860c83513ee50feb9746f3e50d7515d
 - name: github.com/ovh/go-ovh
-  version: d95f6f91b1fb339a53fc438df7289cd85756193b
+  version: 4b1fea467323b74c5f462f0947f402b428ca0626
   subpackages:
   - ovh
 - name: github.com/prometheus/client_golang
@@ -264,7 +264,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: bc8b88226a1210b016e9993b1d75f858c9c8f778
+  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -286,7 +286,7 @@ imports:
 - name: github.com/Sirupsen/logrus
   version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
 - name: github.com/spf13/cobra
-  version: 3c0b56b677e04926dfa835a1b3f11cd4f62f076e
+  version: b78744579491c1ceeaaa3b40205e56b0591b93a3
   subpackages:
   - doc
 - name: github.com/spf13/pflag
@@ -295,6 +295,12 @@ imports:
   version: 37e84520dcf74488f67654f9c775b9752c232dc1
   subpackages:
   - dns
+- name: github.com/tredoe/osutil
+  version: 7d3ee1afa71c90fd1514c8f557ae6c5f414208eb
+  subpackages:
+  - user/crypt
+  - user/crypt/common
+  - user/crypt/sha512_crypt
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -394,7 +400,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/ini.v1
-  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
+  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
 - name: gopkg.in/square/go-jose.v1
   version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,6 +44,7 @@ import:
   version: v0.11.5
 - package: gopkg.in/yaml.v2
   version: v2
+- package: github.com/tredoe/osutil
 testImport:
 - package: github.com/stretchr/testify
   version: v1.1.4

--- a/hack/docker/voyager/templates/default-frontend.cfg
+++ b/hack/docker/voyager/templates/default-frontend.cfg
@@ -5,5 +5,12 @@ frontend http-frontend
 	option httplog
 	option forwardfor
 
+	{{- if .Auth }}
+    {{- range $name, $users := .Auth.Users }}
+    acl __auth_ok__  http_auth({{ $name -}})
+    {{ end -}}
+    http-request auth {{ if ne $.Auth.Realm "" }}realm "{{ $.Auth.Realm }}" {{ end }}if !__auth_ok__
+    {{ end }}
+
 	default_backend {{ .DefaultBackend.Name }}
 

--- a/hack/docker/voyager/templates/default-frontend.cfg
+++ b/hack/docker/voyager/templates/default-frontend.cfg
@@ -6,11 +6,11 @@ frontend http-frontend
 	option forwardfor
 
 	{{- if .Auth }}
-    {{- range $name, $users := .Auth.Users }}
-    acl __auth_ok__  http_auth({{ $name -}})
-    {{ end -}}
-    http-request auth {{ if ne $.Auth.Realm "" }}realm "{{ $.Auth.Realm }}" {{ end }}if !__auth_ok__
-    {{ end }}
+	{{- range $name, $users := .Auth.Users }}
+	acl __auth_ok__  http_auth({{ $name -}})
+	{{ end -}}
+	http-request auth {{ if ne $.Auth.Realm "" }}realm "{{ $.Auth.Realm }}" {{ end }}if !__auth_ok__
+	{{ end }}
 
 	default_backend {{ .DefaultBackend.Name }}
 

--- a/hack/docker/voyager/templates/haproxy.cfg
+++ b/hack/docker/voyager/templates/haproxy.cfg
@@ -31,3 +31,6 @@
 {{ template "default-backend.cfg" .SharedInfo }}
 {{ end }}
 
+{{- if .Auth }}
+{{ template "userlist.cfg" .Auth }}
+{{ end }}

--- a/hack/docker/voyager/templates/http-frontend.cfg
+++ b/hack/docker/voyager/templates/http-frontend.cfg
@@ -16,6 +16,13 @@ frontend {{ .FrontendName }}
 	option forwardfor
 	{{ end }}
 
+	{{- if .Auth }}
+	{{- range $name, $users := .Auth.Users }}
+	acl __auth_ok__  http_auth({{ $name -}})
+	{{ end -}}
+	http-request auth {{ if ne $.Auth.Realm "" }}realm "{{ $.Auth.Realm }}" {{ end }}if !__auth_ok__
+	{{ end }}
+
 	{{- range $path := .Paths }}
 	{{ if  and (or (eq $.Port 80) (eq $.Port 443)) (not $.NodePort) }}
 	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ end }}

--- a/hack/docker/voyager/templates/stats.cfg
+++ b/hack/docker/voyager/templates/stats.cfg
@@ -4,5 +4,5 @@ listen stats
 	stats enable
 	stats realm Haproxy\ Statistics
 	stats uri /
-	{{ if .Username }}stats auth {{ .Username }}:{{ .PassWord }}{{ end -}}
+	{{ if .Username }}stats auth {{ .Username }}:{{ .PassWord }}{{ end }}
 

--- a/hack/docker/voyager/templates/userlist.cfg
+++ b/hack/docker/voyager/templates/userlist.cfg
@@ -1,0 +1,7 @@
+{{ range $name, $users := .Users }}
+userlist {{ $name }}
+	{{- range $user := $users }}
+	user {{ $user.Username }} {{ if not $user.Encrypted }}insecure-{{ end }}password {{ $user.Password -}}
+	{{ end }}
+{{ end }}
+

--- a/hack/example/e2e.yaml
+++ b/hack/example/e2e.yaml
@@ -49,35 +49,15 @@ kind: Ingress
 metadata:
   name: test-ingress
   namespace: default
-  annotations:
-    ingress.appscode.com/type: NodePort
 spec:
   rules:
-  - host: one.example.com
-    http:
-      port: '8989'
-      nodePort: '32666'
+  - http:
       paths:
-      - path: /t1
+      - path: /testpath
         backend:
           serviceName: test-server
-          servicePort: '80'
-      - path: /t2
+          servicePort: 80
+      - path: /
         backend:
           serviceName: test-server
-          servicePort: '80'
-  - host: other.example.com
-    http:
-      port: '8989'
-      nodePort: '32666'
-      paths:
-      - backend:
-          serviceName: test-server
-          servicePort: '80'
-  - host: appscode.example.com
-    tcp:
-      port: '4343'
-      nodePort: '32667'
-      backend:
-        serviceName: test-server
-        servicePort: '80'
+          servicePort: 80

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -57,35 +57,6 @@ func TestTemplate(t *testing.T) {
 				{Name: "first", IP: "10.244.2.2", Port: "2324"},
 			},
 		},
-		Auth: &AuthConfig{
-			Realm: "Required",
-			Users: map[string][]AuthUser{
-				"auth": {
-					{
-						Username: "foo",
-						Password: "bar",
-						Encrypted: true,
-					},
-					{
-						Username: "foo2",
-						Password: "bar2",
-						Encrypted: false,
-					},
-				},
-				"auth2": {
-					{
-						Username: "foo",
-						Password: "bar",
-						Encrypted: true,
-					},
-					{
-						Username: "foo2",
-						Password: "bar2",
-						Encrypted: false,
-					},
-				},
-			},
-		},
 	}
 	testParsedConfig := TemplateData{
 		SharedInfo: si,

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -57,6 +57,35 @@ func TestTemplate(t *testing.T) {
 				{Name: "first", IP: "10.244.2.2", Port: "2324"},
 			},
 		},
+		Auth: &AuthConfig{
+			Realm: "Required",
+			Users: map[string][]AuthUser{
+				"auth": {
+					{
+						Username: "foo",
+						Password: "bar",
+						Encrypted: true,
+					},
+					{
+						Username: "foo2",
+						Password: "bar2",
+						Encrypted: false,
+					},
+				},
+				"auth2": {
+					{
+						Username: "foo",
+						Password: "bar",
+						Encrypted: true,
+					},
+					{
+						Username: "foo2",
+						Password: "bar2",
+						Encrypted: false,
+					},
+				},
+			},
+		},
 	}
 	testParsedConfig := TemplateData{
 		SharedInfo: si,
@@ -340,3 +369,124 @@ func TestTemplate(t *testing.T) {
 		}
 	}
 }
+
+func TestTemplateAuth(t *testing.T) {
+	si := &SharedInfo{
+		DefaultBackend: &Backend{
+			Name:         "default",
+			Endpoints: []*Endpoint{
+				{Name: "first", IP: "10.244.2.1", Port: "2323"},
+				{Name: "first", IP: "10.244.2.2", Port: "2324"},
+			},
+		},
+		Auth: &AuthConfig{
+			Realm: "Required",
+			Users: map[string][]AuthUser{
+				"auth": {
+					{
+						Username: "foo",
+						Password: "#bar",
+						Encrypted: true,
+					},
+					{
+						Username: "foo2",
+						Password: "bar2",
+						Encrypted: false,
+					},
+				},
+				"auth2": {
+					{
+						Username: "foo",
+						Password: "#bar",
+						Encrypted: true,
+					},
+					{
+						Username: "foo2",
+						Password: "bar2",
+						Encrypted: false,
+					},
+				},
+			},
+		},
+	}
+	testParsedConfig := TemplateData{
+		SharedInfo: si,
+		TimeoutDefaults: map[string]string{
+			"client": "2s",
+			"fin":    "1d",
+		},
+		HTTPService: []*HTTPService{
+			{
+				SharedInfo:    si,
+				FrontendName:  "one",
+				Port:          80,
+				FrontendRules: []string{},
+				Paths: []*HTTPPath{
+					{
+						Path: "/elijah",
+						Backend: Backend{
+							Name:         "elijah",
+							Endpoints: []*Endpoint{
+								{Name: "first", IP: "10.244.2.1", Port: "2323"},
+								{Name: "first", IP: "10.244.2.2", Port: "2324"},
+							},
+						},
+					},
+					{
+						Path: "/nicklause",
+						Backend: Backend{
+							Name: "nicklause",
+							Endpoints: []*Endpoint{
+								{Name: "first", IP: "10.244.2.1", Port: "2323"},
+								{Name: "first", IP: "10.244.2.2", Port: "2324", CheckHealth: true},
+							},
+						},
+					},
+				},
+			},
+			{
+				SharedInfo:    si,
+				FrontendName:  "two",
+				Port:          933,
+				FrontendRules: []string{},
+				Paths: []*HTTPPath{
+					{
+						Path: "/kool",
+						Backend: Backend{
+							Name:         "kool",
+							Endpoints: []*Endpoint{
+								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true},
+								{Name: "first", IP: "10.244.2.2", Port: "2324"},
+							},
+						},
+					},
+				},
+			},
+		},
+		TCPService: []*TCPService{
+			{
+				SharedInfo:    si,
+				FrontendName:  "stefan",
+				Port:          "333",
+				FrontendRules: []string{},
+				Backend: Backend{
+					Name:         "stefan",
+					BackendRules: []string{"first rule", "second rule"},
+					Endpoints: []*Endpoint{
+						{Name: "first", IP: "10.244.2.1", Port: "2323"},
+						{Name: "first", IP: "10.244.2.2", Port: "2324"},
+					},
+				},
+			},
+		},
+	}
+	err := LoadTemplates(runtime.GOPath()+"/src/github.com/appscode/voyager/hack/docker/voyager/templates/*.cfg", "")
+	if assert.Nil(t, err) {
+		config, err := RenderConfig(testParsedConfig)
+		assert.Nil(t, err)
+		if testing.Verbose() {
+			fmt.Println(err, "\n", config)
+		}
+	}
+}
+

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -344,7 +344,7 @@ func TestTemplate(t *testing.T) {
 func TestTemplateAuth(t *testing.T) {
 	si := &SharedInfo{
 		DefaultBackend: &Backend{
-			Name:         "default",
+			Name: "default",
 			Endpoints: []*Endpoint{
 				{Name: "first", IP: "10.244.2.1", Port: "2323"},
 				{Name: "first", IP: "10.244.2.2", Port: "2324"},
@@ -355,25 +355,25 @@ func TestTemplateAuth(t *testing.T) {
 			Users: map[string][]AuthUser{
 				"auth": {
 					{
-						Username: "foo",
-						Password: "#bar",
+						Username:  "foo",
+						Password:  "#bar",
 						Encrypted: true,
 					},
 					{
-						Username: "foo2",
-						Password: "bar2",
+						Username:  "foo2",
+						Password:  "bar2",
 						Encrypted: false,
 					},
 				},
 				"auth2": {
 					{
-						Username: "foo",
-						Password: "#bar",
+						Username:  "foo",
+						Password:  "#bar",
 						Encrypted: true,
 					},
 					{
-						Username: "foo2",
-						Password: "bar2",
+						Username:  "foo2",
+						Password:  "bar2",
 						Encrypted: false,
 					},
 				},
@@ -396,7 +396,7 @@ func TestTemplateAuth(t *testing.T) {
 					{
 						Path: "/elijah",
 						Backend: Backend{
-							Name:         "elijah",
+							Name: "elijah",
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323"},
 								{Name: "first", IP: "10.244.2.2", Port: "2324"},
@@ -424,7 +424,7 @@ func TestTemplateAuth(t *testing.T) {
 					{
 						Path: "/kool",
 						Backend: Backend{
-							Name:         "kool",
+							Name: "kool",
 							Endpoints: []*Endpoint{
 								{Name: "first", IP: "10.244.2.1", Port: "2323", UseDNSResolver: true},
 								{Name: "first", IP: "10.244.2.2", Port: "2324"},
@@ -460,4 +460,3 @@ func TestTemplateAuth(t *testing.T) {
 		}
 	}
 }
-

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -21,6 +21,7 @@ type SharedInfo struct {
 	// Add accept-proxy to bind statements
 	AcceptProxy    bool
 	DefaultBackend *Backend
+	Auth           *AuthConfig
 }
 
 type StatsInfo struct {
@@ -102,4 +103,15 @@ type Endpoint struct {
 	CheckHealth    bool
 
 	TLSOption string
+}
+
+type AuthConfig struct {
+	Realm string
+	Users map[string][]AuthUser
+}
+
+type AuthUser struct {
+	Username  string
+	Password  string
+	Encrypted bool
 }

--- a/pkg/ingress/parser.go
+++ b/pkg/ingress/parser.go
@@ -1,6 +1,8 @@
 package ingress
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -226,6 +228,21 @@ func (c *controller) generateConfig() error {
 		}
 	}
 
+	if c.Ingress.AuthEnabled() {
+		si.Auth = &haproxy.AuthConfig{
+			Realm: c.Ingress.AuthRealm(),
+		}
+
+		secret, err := c.KubeClient.CoreV1().Secrets(c.Ingress.Namespace).Get(c.Ingress.AuthSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if secret.Data == nil {
+			return fmt.Errorf("secret data missing")
+		}
+		si.Auth.Users = getAuthUsers(secret.Data)
+	}
+
 	td.SharedInfo = si
 	td.TimeoutDefaults = c.Ingress.Timeouts()
 	td.OptionsDefaults = c.Ingress.HAProxyOptions()
@@ -364,6 +381,52 @@ func (c *controller) generateConfig() error {
 		log.Debugf("Generated haproxy.cfg for Ingress %s@%s:", c.Ingress.Name, c.Ingress.Namespace, cfg)
 	}
 	return nil
+}
+
+func getAuthUsers(data map[string][]byte) map[string][]haproxy.AuthUser {
+	ret := make(map[string][]haproxy.AuthUser, 0)
+	for name, data := range data {
+		users := make([]haproxy.AuthUser, 0)
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if len(line) <= 0 {
+				continue
+			}
+			sep := strings.Index(line, ":")
+			if sep == -1 {
+				log.Warningf("Missing ':' on userlist")
+				continue
+			}
+			userName := line[0:sep]
+			if userName == "" {
+				log.Warningf("Missing username on userlist")
+				continue
+			}
+			if sep == len(line)-1 || line[sep:] == "::" {
+				log.Warningf("Missing '%v' password on userlist", userName)
+				continue
+			}
+			user := haproxy.AuthUser{}
+			// if usr::pwd
+			if string(line[sep+1]) == ":" {
+				user = haproxy.AuthUser{
+					Username:  userName,
+					Password:  line[sep+2:],
+					Encrypted: false,
+				}
+			} else {
+				user = haproxy.AuthUser{
+					Username:  userName,
+					Password:  line[sep+1:],
+					Encrypted: true,
+				}
+			}
+			users = append(users, user)
+		}
+		ret[name] = users
+	}
+	return ret
 }
 
 func getFrontendRulesForPort(rules []api.FrontendRule, port int) []string {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 		err := op.Setup()
 		Expect(err).NotTo(HaveOccurred())
 
-		err = haproxy.LoadTemplates(runtime.GOPath()+"/src/github.com/appscode/voyager/hack/docker/voyager/templates/*", "")
+		err = haproxy.LoadTemplates(runtime.GOPath()+"/src/github.com/appscode/voyager/hack/docker/voyager/templates/*.cfg", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		go op.Run()

--- a/test/e2e/ingress_basicauth.go
+++ b/test/e2e/ingress_basicauth.go
@@ -1,0 +1,156 @@
+package e2e
+
+import (
+	"net/http"
+
+	"github.com/appscode/voyager/api"
+	"github.com/appscode/voyager/test/framework"
+	"github.com/appscode/voyager/test/test-server/testserverclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var _ = Describe("IngressWithBasicAuth", func() {
+	var (
+		f      *framework.Invocation
+		ing    *api.Ingress
+		secret *apiv1.Secret
+	)
+
+	BeforeEach(func() {
+		f = root.Invoke()
+		ing = f.Ingress.GetSkeleton()
+		f.Ingress.SetSkeletonRule(ing)
+	})
+
+	BeforeEach(func() {
+		secret = &apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      f.Ingress.UniqueName(),
+				Namespace: ing.GetNamespace(),
+			},
+			StringData: map[string]string{
+				"auth": `foo::bar
+				jane:E5BrlrQ5IXYK2`,
+
+				"auth2": `auth2-foo::bar
+				auth2-jane:E5BrlrQ5IXYK2`,
+			},
+		}
+		_, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Create(secret)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		By("Creating ingress with name " + ing.GetName())
+		err := f.Ingress.Create(ing)
+		Expect(err).NotTo(HaveOccurred())
+
+		f.Ingress.EventuallyStarted(ing).Should(BeTrue())
+
+		By("Checking generated resource")
+		Expect(f.Ingress.IsExistsEventually(ing)).Should(BeTrue())
+	})
+
+	AfterEach(func() {
+		if root.Config.Cleanup {
+			f.Ingress.Delete(ing)
+			f.KubeClient.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+		}
+	})
+
+	Describe("Create", func() {
+		BeforeEach(func() {
+			ing.Annotations = map[string]string{
+				api.AuthType:   "basic",
+				api.AuthRealm:  "Realm returned",
+				api.AuthSecret: secret.Name,
+			}
+			ing.Spec.Rules = []api.IngressRule{
+				{
+					IngressRuleValue: api.IngressRuleValue{
+						HTTP: &api.HTTPIngressRuleValue{
+							Paths: []api.HTTPIngressPath{
+								{
+									Path: "/testpath",
+									Backend: api.HTTPIngressBackend{
+										IngressBackend: api.IngressBackend{
+											ServiceName: f.Ingress.TestServerName(),
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("Should response HTTP weighted", func() {
+			By("Getting HTTP endpoints")
+			eps, err := f.Ingress.GetHTTPEndpoints(ing)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(eps)).Should(BeNumerically(">=", 1))
+
+			err = f.Ingress.DoHTTPStatus(framework.NoRetry, ing, eps, "GET", "/testpath", func(r *testserverclient.Response) bool {
+				return Expect(r.Status).Should(Equal(http.StatusUnauthorized))
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = f.Ingress.DoHTTPWithHeader(
+				framework.MaxRetry,
+				ing,
+				eps,
+				"GET",
+				"/testpath",
+				map[string]string{
+					"Authorization": "Basic Zm9vOmJhcg==",
+				},
+				func(r *testserverclient.Response) bool {
+					return Expect(r.Status).Should(Equal(http.StatusOK)) &&
+						Expect(r.Method).Should(Equal("GET")) &&
+						Expect(r.Path).Should(Equal("/testpath"))
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = f.Ingress.DoHTTPWithHeader(
+				framework.MaxRetry,
+				ing,
+				eps,
+				"GET",
+				"/testpath",
+				map[string]string{
+					"Authorization": "Basic YXV0aDItZm9vOmJhcg==",
+				},
+				func(r *testserverclient.Response) bool {
+					return Expect(r.Status).Should(Equal(http.StatusOK)) &&
+						Expect(r.Method).Should(Equal("GET")) &&
+						Expect(r.Path).Should(Equal("/testpath"))
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = f.Ingress.DoHTTPWithHeader(
+				framework.MaxRetry,
+				ing,
+				eps,
+				"GET",
+				"/testpath",
+				map[string]string{
+					"Authorization": "Basic amFuZTpndWVzdA==",
+				},
+				func(r *testserverclient.Response) bool {
+					return Expect(r.Status).Should(Equal(http.StatusOK)) &&
+						Expect(r.Method).Should(Equal("GET")) &&
+						Expect(r.Path).Should(Equal("/testpath"))
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/vendor/github.com/ovh/go-ovh/ovh/ovh.go
+++ b/vendor/github.com/ovh/go-ovh/ovh/ovh.go
@@ -188,9 +188,10 @@ func (c *Client) getResponse(response *http.Response, resType interface{}) error
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		apiError := &APIError{Code: response.StatusCode}
 		if err = json.Unmarshal(body, apiError); err != nil {
-			return err
+			apiError.Message = string(body)
 		}
 		apiError.QueryID = response.Header.Get("X-Ovh-QueryID")
+
 		return apiError
 	}
 

--- a/vendor/github.com/spf13/cobra/bash_completions.go
+++ b/vendor/github.com/spf13/cobra/bash_completions.go
@@ -463,14 +463,14 @@ func gen(buf *bytes.Buffer, cmd *Command) {
 }
 
 // GenBashCompletion generates bash completion file and writes to the passed writer.
-func (cmd *Command) GenBashCompletion(w io.Writer) error {
+func (c *Command) GenBashCompletion(w io.Writer) error {
 	buf := new(bytes.Buffer)
-	writePreamble(buf, cmd.Name())
-	if len(cmd.BashCompletionFunction) > 0 {
-		buf.WriteString(cmd.BashCompletionFunction + "\n")
+	writePreamble(buf, c.Name())
+	if len(c.BashCompletionFunction) > 0 {
+		buf.WriteString(c.BashCompletionFunction + "\n")
 	}
-	gen(buf, cmd)
-	writePostscript(buf, cmd.Name())
+	gen(buf, c)
+	writePostscript(buf, c.Name())
 
 	_, err := buf.WriteTo(w)
 	return err
@@ -481,24 +481,24 @@ func nonCompletableFlag(flag *pflag.Flag) bool {
 }
 
 // GenBashCompletionFile generates bash completion file.
-func (cmd *Command) GenBashCompletionFile(filename string) error {
+func (c *Command) GenBashCompletionFile(filename string) error {
 	outFile, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
 	defer outFile.Close()
 
-	return cmd.GenBashCompletion(outFile)
+	return c.GenBashCompletion(outFile)
 }
 
 // MarkFlagRequired adds the BashCompOneRequiredFlag annotation to the named flag, if it exists.
-func (cmd *Command) MarkFlagRequired(name string) error {
-	return MarkFlagRequired(cmd.Flags(), name)
+func (c *Command) MarkFlagRequired(name string) error {
+	return MarkFlagRequired(c.Flags(), name)
 }
 
 // MarkPersistentFlagRequired adds the BashCompOneRequiredFlag annotation to the named persistent flag, if it exists.
-func (cmd *Command) MarkPersistentFlagRequired(name string) error {
-	return MarkFlagRequired(cmd.PersistentFlags(), name)
+func (c *Command) MarkPersistentFlagRequired(name string) error {
+	return MarkFlagRequired(c.PersistentFlags(), name)
 }
 
 // MarkFlagRequired adds the BashCompOneRequiredFlag annotation to the named flag in the flag set, if it exists.
@@ -508,20 +508,20 @@ func MarkFlagRequired(flags *pflag.FlagSet, name string) error {
 
 // MarkFlagFilename adds the BashCompFilenameExt annotation to the named flag, if it exists.
 // Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
-func (cmd *Command) MarkFlagFilename(name string, extensions ...string) error {
-	return MarkFlagFilename(cmd.Flags(), name, extensions...)
+func (c *Command) MarkFlagFilename(name string, extensions ...string) error {
+	return MarkFlagFilename(c.Flags(), name, extensions...)
 }
 
 // MarkFlagCustom adds the BashCompCustom annotation to the named flag, if it exists.
 // Generated bash autocompletion will call the bash function f for the flag.
-func (cmd *Command) MarkFlagCustom(name string, f string) error {
-	return MarkFlagCustom(cmd.Flags(), name, f)
+func (c *Command) MarkFlagCustom(name string, f string) error {
+	return MarkFlagCustom(c.Flags(), name, f)
 }
 
 // MarkPersistentFlagFilename adds the BashCompFilenameExt annotation to the named persistent flag, if it exists.
 // Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
-func (cmd *Command) MarkPersistentFlagFilename(name string, extensions ...string) error {
-	return MarkFlagFilename(cmd.PersistentFlags(), name, extensions...)
+func (c *Command) MarkPersistentFlagFilename(name string, extensions ...string) error {
+	return MarkFlagFilename(c.PersistentFlags(), name, extensions...)
 }
 
 // MarkFlagFilename adds the BashCompFilenameExt annotation to the named flag in the flag set, if it exists.

--- a/vendor/github.com/spf13/cobra/zsh_completions.go
+++ b/vendor/github.com/spf13/cobra/zsh_completions.go
@@ -4,17 +4,29 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
+// GenZshCompletionFile generates zsh completion file.
+func (c *Command) GenZshCompletionFile(filename string) error {
+	outFile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	return c.GenZshCompletion(outFile)
+}
+
 // GenZshCompletion generates a zsh completion file and writes to the passed writer.
-func (cmd *Command) GenZshCompletion(w io.Writer) error {
+func (c *Command) GenZshCompletion(w io.Writer) error {
 	buf := new(bytes.Buffer)
 
-	writeHeader(buf, cmd)
-	maxDepth := maxDepth(cmd)
+	writeHeader(buf, c)
+	maxDepth := maxDepth(c)
 	writeLevelMapping(buf, maxDepth)
-	writeLevelCases(buf, maxDepth, cmd)
+	writeLevelCases(buf, maxDepth, c)
 
 	_, err := buf.WriteTo(w)
 	return err

--- a/vendor/github.com/tredoe/osutil/LICENSE-MPL.txt
+++ b/vendor/github.com/tredoe/osutil/LICENSE-MPL.txt
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/tredoe/osutil/user/crypt/LICENSE
+++ b/vendor/github.com/tredoe/osutil/user/crypt/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012, Jeramey Crawford <jeramey@antihe.ro>
+Copyright (c) 2013, Jonas mg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/tredoe/osutil/user/crypt/common/base64.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/common/base64.go
@@ -1,0 +1,60 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+package common
+
+const alphabet = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// Base64_24Bit is a variant of Base64 encoding, commonly used with password
+// hashing algorithms to encode the result of their checksum output.
+//
+// The algorithm operates on up to 3 bytes at a time, encoding the following
+// 6-bit sequences into up to 4 hash64 ASCII bytes.
+//
+//   1. Bottom 6 bits of the first byte
+//   2. Top 2 bits of the first byte, and bottom 4 bits of the second byte.
+//   3. Top 4 bits of the second byte, and bottom 2 bits of the third byte.
+//   4. Top 6 bits of the third byte.
+//
+// This encoding method does not emit padding bytes as Base64 does.
+func Base64_24Bit(src []byte) (hash []byte) {
+	if len(src) == 0 {
+		return []byte{} // TODO: return nil
+	}
+
+	hashSize := (len(src) * 8) / 6
+	if (len(src) % 6) != 0 {
+		hashSize += 1
+	}
+	hash = make([]byte, hashSize)
+
+	dst := hash
+	for len(src) > 0 {
+		switch len(src) {
+		default:
+			dst[0] = alphabet[src[0]&0x3f]
+			dst[1] = alphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
+			dst[2] = alphabet[((src[1]>>4)|(src[2]<<4))&0x3f]
+			dst[3] = alphabet[(src[2]>>2)&0x3f]
+			src = src[3:]
+			dst = dst[4:]
+		case 2:
+			dst[0] = alphabet[src[0]&0x3f]
+			dst[1] = alphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
+			dst[2] = alphabet[(src[1]>>4)&0x3f]
+			src = src[2:]
+			dst = dst[3:]
+		case 1:
+			dst[0] = alphabet[src[0]&0x3f]
+			dst[1] = alphabet[(src[0]>>6)&0x3f]
+			src = src[1:]
+			dst = dst[2:]
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/common/doc.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/common/doc.go
@@ -1,0 +1,13 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package common contains routines used by multiple password hashing
+// algorithms.
+//
+// Generally, you will never import this package directly. Many of the
+// *_crypt packages will import this package if they require it.
+package common

--- a/vendor/github.com/tredoe/osutil/user/crypt/common/salt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/common/salt.go
@@ -1,0 +1,105 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+package common
+
+import (
+	"crypto/rand"
+	"errors"
+	"strconv"
+)
+
+var (
+	ErrSaltPrefix = errors.New("invalid magic prefix")
+	ErrSaltFormat = errors.New("invalid salt format")
+	ErrSaltRounds = errors.New("invalid rounds")
+)
+
+// Salt represents a salt.
+type Salt struct {
+	MagicPrefix []byte
+
+	SaltLenMin int
+	SaltLenMax int
+
+	RoundsMin     int
+	RoundsMax     int
+	RoundsDefault int
+}
+
+// Generate generates a random salt of a given length.
+//
+// The length is set thus:
+//
+//   length > SaltLenMax: length = SaltLenMax
+//   length < SaltLenMin: length = SaltLenMin
+func (s *Salt) Generate(length int) []byte {
+	if length > s.SaltLenMax {
+		length = s.SaltLenMax
+	} else if length < s.SaltLenMin {
+		length = s.SaltLenMin
+	}
+
+	saltLen := (length * 6 / 8)
+	if (length*6)%8 != 0 {
+		saltLen += 1
+	}
+	salt := make([]byte, saltLen)
+	rand.Read(salt)
+
+	out := make([]byte, len(s.MagicPrefix)+length)
+	copy(out, s.MagicPrefix)
+	copy(out[len(s.MagicPrefix):], Base64_24Bit(salt))
+	return out
+}
+
+// GenerateWRounds creates a random salt with the random bytes being of the
+// length provided, and the rounds parameter set as specified.
+//
+// The parameters are set thus:
+//
+//   length > SaltLenMax: length = SaltLenMax
+//   length < SaltLenMin: length = SaltLenMin
+//
+//   rounds < 0: rounds = RoundsDefault
+//   rounds < RoundsMin: rounds = RoundsMin
+//   rounds > RoundsMax: rounds = RoundsMax
+//
+// If rounds is equal to RoundsDefault, then the "rounds=" part of the salt is
+// removed.
+func (s *Salt) GenerateWRounds(length, rounds int) []byte {
+	if length > s.SaltLenMax {
+		length = s.SaltLenMax
+	} else if length < s.SaltLenMin {
+		length = s.SaltLenMin
+	}
+	if rounds < 0 {
+		rounds = s.RoundsDefault
+	} else if rounds < s.RoundsMin {
+		rounds = s.RoundsMin
+	} else if rounds > s.RoundsMax {
+		rounds = s.RoundsMax
+	}
+
+	saltLen := (length * 6 / 8)
+	if (length*6)%8 != 0 {
+		saltLen += 1
+	}
+	salt := make([]byte, saltLen)
+	rand.Read(salt)
+
+	roundsText := ""
+	if rounds != s.RoundsDefault {
+		roundsText = "rounds=" + strconv.Itoa(rounds)
+	}
+
+	out := make([]byte, len(s.MagicPrefix)+len(roundsText)+length)
+	copy(out, s.MagicPrefix)
+	copy(out[len(s.MagicPrefix):], []byte(roundsText))
+	copy(out[len(s.MagicPrefix)+len(roundsText):], Base64_24Bit(salt))
+	return out
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/crypt.go
@@ -1,0 +1,108 @@
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package crypt provides interface for password crypt functions and collects
+// common constants.
+package crypt
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/tredoe/osutil/user/crypt/common"
+)
+
+var ErrKeyMismatch = errors.New("hashed value is not the hash of the given password")
+
+// Crypter is the common interface implemented by all crypt functions.
+type Crypter interface {
+	// Generate performs the hashing algorithm, returning a full hash suitable
+	// for storage and later password verification.
+	//
+	// If the salt is empty, a randomly-generated salt will be generated with a
+	// length of SaltLenMax and number RoundsDefault of rounds.
+	//
+	// Any error only can be got when the salt argument is not empty.
+	Generate(key, salt []byte) (string, error)
+
+	// Verify compares a hashed key with its possible key equivalent.
+	// Returns nil on success, or an error on failure; if the hashed key is
+	// diffrent, the error is "ErrKeyMismatch".
+	Verify(hashedKey string, key []byte) error
+
+	// Cost returns the hashing cost (in rounds) used to create the given hashed
+	// key.
+	//
+	// When, in the future, the hashing cost of a key needs to be increased in
+	// order to adjust for greater computational power, this function allows one
+	// to establish which keys need to be updated.
+	//
+	// The algorithms based in MD5-crypt use a fixed value of rounds.
+	Cost(hashedKey string) (int, error)
+
+	// SetSalt sets a different salt. It is used to easily create derivated
+	// algorithms, i.e. "apr1_crypt" from "md5_crypt".
+	SetSalt(salt common.Salt)
+}
+
+// Crypt identifies a crypt function that is implemented in another package.
+type Crypt uint
+
+const (
+	APR1   Crypt = iota + 1 // import "github.com/tredoe/osutil/user/crypt/apr1_crypt"
+	MD5                     // import "github.com/tredoe/osutil/user/crypt/md5_crypt"
+	SHA256                  // import "github.com/tredoe/osutil/user/crypt/sha256_crypt"
+	SHA512                  // import "github.com/tredoe/osutil/user/crypt/sha512_crypt"
+	maxCrypt
+)
+
+var cryptPrefixes = make([]string, maxCrypt)
+
+var crypts = make([]func() Crypter, maxCrypt)
+
+// RegisterCrypt registers a function that returns a new instance of the given
+// crypt function. This is intended to be called from the init function in
+// packages that implement crypt functions.
+func RegisterCrypt(c Crypt, f func() Crypter, prefix string) {
+	if c >= maxCrypt {
+		panic("crypt: RegisterHash of unknown crypt function")
+	}
+	crypts[c] = f
+	cryptPrefixes[c] = prefix
+}
+
+// New returns a new crypter.
+func New(c Crypt) Crypter {
+	f := crypts[c]
+	if f != nil {
+		return f()
+	}
+	panic("crypt: requested crypt function is unavailable")
+}
+
+// NewFromHash returns a new Crypter using the prefix in the given hashed key.
+func NewFromHash(hashedKey string) Crypter {
+	var f func() Crypter
+
+	if strings.HasPrefix(hashedKey, cryptPrefixes[SHA512]) {
+		f = crypts[SHA512]
+	} else if strings.HasPrefix(hashedKey, cryptPrefixes[SHA256]) {
+		f = crypts[SHA256]
+	} else if strings.HasPrefix(hashedKey, cryptPrefixes[MD5]) {
+		f = crypts[MD5]
+	} else if strings.HasPrefix(hashedKey, cryptPrefixes[APR1]) {
+		f = crypts[APR1]
+	} else {
+		toks := strings.SplitN(hashedKey, "$", 3)
+		prefix := "$" + toks[1] + "$"
+		panic("crypt: unknown cryp function from prefix: " + prefix)
+	}
+
+	if f != nil {
+		return f()
+	}
+	panic("crypt: requested cryp function is unavailable")
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/sha512_crypt/sha512_crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/sha512_crypt/sha512_crypt.go
@@ -1,0 +1,254 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package sha512_crypt implements Ulrich Drepper's SHA512-crypt password
+// hashing algorithm.
+//
+// The specification for this algorithm can be found here:
+// http://www.akkadia.org/drepper/SHA-crypt.txt
+package sha512_crypt
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"strconv"
+
+	"github.com/tredoe/osutil/user/crypt"
+	"github.com/tredoe/osutil/user/crypt/common"
+)
+
+func init() {
+	crypt.RegisterCrypt(crypt.SHA512, New, MagicPrefix)
+}
+
+const (
+	MagicPrefix   = "$6$"
+	SaltLenMin    = 1
+	SaltLenMax    = 16
+	RoundsMin     = 1000
+	RoundsMax     = 999999999
+	RoundsDefault = 5000
+)
+
+var _rounds = []byte("rounds=")
+
+type crypter struct{ Salt common.Salt }
+
+// New returns a new crypt.Crypter computing the SHA512-crypt password hashing.
+func New() crypt.Crypter {
+	return &crypter{GetSalt()}
+}
+
+func (c *crypter) Generate(key, salt []byte) (string, error) {
+	var rounds int
+	var isRoundsDef bool
+
+	if len(salt) == 0 {
+		salt = c.Salt.GenerateWRounds(SaltLenMax, RoundsDefault)
+	}
+	if !bytes.HasPrefix(salt, c.Salt.MagicPrefix) {
+		return "", common.ErrSaltPrefix
+	}
+
+	saltToks := bytes.Split(salt, []byte{'$'})
+	if len(saltToks) < 3 {
+		return "", common.ErrSaltFormat
+	}
+
+	if bytes.HasPrefix(saltToks[2], _rounds) {
+		isRoundsDef = true
+		pr, err := strconv.ParseInt(string(saltToks[2][7:]), 10, 32)
+		if err != nil {
+			return "", common.ErrSaltRounds
+		}
+		rounds = int(pr)
+		if rounds < RoundsMin {
+			rounds = RoundsMin
+		} else if rounds > RoundsMax {
+			rounds = RoundsMax
+		}
+		salt = saltToks[3]
+	} else {
+		rounds = RoundsDefault
+		salt = saltToks[2]
+	}
+
+	if len(salt) > SaltLenMax {
+		salt = salt[0:SaltLenMax]
+	}
+
+	// Compute alternate SHA512 sum with input KEY, SALT, and KEY.
+	Alternate := sha512.New()
+	Alternate.Write(key)
+	Alternate.Write(salt)
+	Alternate.Write(key)
+	AlternateSum := Alternate.Sum(nil) // 64 bytes
+
+	A := sha512.New()
+	A.Write(key)
+	A.Write(salt)
+	// Add for any character in the key one byte of the alternate sum.
+	i := len(key)
+	for ; i > 64; i -= 64 {
+		A.Write(AlternateSum)
+	}
+	A.Write(AlternateSum[0:i])
+
+	// Take the binary representation of the length of the key and for every add
+	// the alternate sum, for every 0 the key.
+	for i = len(key); i > 0; i >>= 1 {
+		if (i & 1) != 0 {
+			A.Write(AlternateSum)
+		} else {
+			A.Write(key)
+		}
+	}
+	Asum := A.Sum(nil)
+
+	// Start computation of P byte sequence.
+	P := sha512.New()
+	// For every character in the password add the entire password.
+	for i = 0; i < len(key); i++ {
+		P.Write(key)
+	}
+	Psum := P.Sum(nil)
+	// Create byte sequence P.
+	Pseq := make([]byte, 0, len(key))
+	for i = len(key); i > 64; i -= 64 {
+		Pseq = append(Pseq, Psum...)
+	}
+	Pseq = append(Pseq, Psum[0:i]...)
+
+	// Start computation of S byte sequence.
+	S := sha512.New()
+	for i = 0; i < (16 + int(Asum[0])); i++ {
+		S.Write(salt)
+	}
+	Ssum := S.Sum(nil)
+	// Create byte sequence S.
+	Sseq := make([]byte, 0, len(salt))
+	for i = len(salt); i > 64; i -= 64 {
+		Sseq = append(Sseq, Ssum...)
+	}
+	Sseq = append(Sseq, Ssum[0:i]...)
+
+	Csum := Asum
+
+	// Repeatedly run the collected hash value through SHA512 to burn CPU cycles.
+	for i = 0; i < rounds; i++ {
+		C := sha512.New()
+
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(Pseq)
+		} else {
+			C.Write(Csum)
+		}
+		// Add salt for numbers not divisible by 3.
+		if (i % 3) != 0 {
+			C.Write(Sseq)
+		}
+		// Add key for numbers not divisible by 7.
+		if (i % 7) != 0 {
+			C.Write(Pseq)
+		}
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(Csum)
+		} else {
+			C.Write(Pseq)
+		}
+
+		Csum = C.Sum(nil)
+	}
+
+	out := make([]byte, 0, 123)
+	out = append(out, c.Salt.MagicPrefix...)
+	if isRoundsDef {
+		out = append(out, []byte("rounds="+strconv.Itoa(rounds)+"$")...)
+	}
+	out = append(out, salt...)
+	out = append(out, '$')
+	out = append(out, common.Base64_24Bit([]byte{
+		Csum[42], Csum[21], Csum[0],
+		Csum[1], Csum[43], Csum[22],
+		Csum[23], Csum[2], Csum[44],
+		Csum[45], Csum[24], Csum[3],
+		Csum[4], Csum[46], Csum[25],
+		Csum[26], Csum[5], Csum[47],
+		Csum[48], Csum[27], Csum[6],
+		Csum[7], Csum[49], Csum[28],
+		Csum[29], Csum[8], Csum[50],
+		Csum[51], Csum[30], Csum[9],
+		Csum[10], Csum[52], Csum[31],
+		Csum[32], Csum[11], Csum[53],
+		Csum[54], Csum[33], Csum[12],
+		Csum[13], Csum[55], Csum[34],
+		Csum[35], Csum[14], Csum[56],
+		Csum[57], Csum[36], Csum[15],
+		Csum[16], Csum[58], Csum[37],
+		Csum[38], Csum[17], Csum[59],
+		Csum[60], Csum[39], Csum[18],
+		Csum[19], Csum[61], Csum[40],
+		Csum[41], Csum[20], Csum[62],
+		Csum[63],
+	})...)
+
+	// Clean sensitive data.
+	A.Reset()
+	Alternate.Reset()
+	P.Reset()
+	for i = 0; i < len(Asum); i++ {
+		Asum[i] = 0
+	}
+	for i = 0; i < len(AlternateSum); i++ {
+		AlternateSum[i] = 0
+	}
+	for i = 0; i < len(Pseq); i++ {
+		Pseq[i] = 0
+	}
+
+	return string(out), nil
+}
+
+func (c *crypter) Verify(hashedKey string, key []byte) error {
+	newHash, err := c.Generate(key, []byte(hashedKey))
+	if err != nil {
+		return err
+	}
+	if newHash != hashedKey {
+		return crypt.ErrKeyMismatch
+	}
+	return nil
+}
+
+func (c *crypter) Cost(hashedKey string) (int, error) {
+	saltToks := bytes.Split([]byte(hashedKey), []byte{'$'})
+	if len(saltToks) < 3 {
+		return 0, common.ErrSaltFormat
+	}
+
+	if !bytes.HasPrefix(saltToks[2], _rounds) {
+		return RoundsDefault, nil
+	}
+	roundToks := bytes.Split(saltToks[2], []byte{'='})
+	cost, err := strconv.ParseInt(string(roundToks[1]), 10, 0)
+	return int(cost), err
+}
+
+func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+		RoundsMin:     RoundsMin,
+		RoundsMax:     RoundsMax,
+	}
+}

--- a/vendor/gopkg.in/ini.v1/ini.go
+++ b/vendor/gopkg.in/ini.v1/ini.go
@@ -24,10 +24,8 @@ import (
 	"os"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 const (
@@ -37,7 +35,7 @@ const (
 
 	// Maximum allowed depth when recursively substituing variable names.
 	_DEPTH_VALUES = 99
-	_VERSION      = "1.28.0"
+	_VERSION      = "1.28.2"
 )
 
 // Version returns current package version literal.
@@ -398,10 +396,7 @@ func (f *File) Append(source interface{}, others ...interface{}) error {
 	return f.Reload()
 }
 
-// WriteToIndent writes content into io.Writer with given indention.
-// If PrettyFormat has been set to be true,
-// it will align "=" sign with spaces under each section.
-func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
+func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 	equalSign := "="
 	if PrettyFormat {
 		equalSign = " = "
@@ -415,14 +410,14 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 			if sec.Comment[0] != '#' && sec.Comment[0] != ';' {
 				sec.Comment = "; " + sec.Comment
 			}
-			if _, err = buf.WriteString(sec.Comment + LineBreak); err != nil {
-				return 0, err
+			if _, err := buf.WriteString(sec.Comment + LineBreak); err != nil {
+				return nil, err
 			}
 		}
 
 		if i > 0 || DefaultHeader {
-			if _, err = buf.WriteString("[" + sname + "]" + LineBreak); err != nil {
-				return 0, err
+			if _, err := buf.WriteString("[" + sname + "]" + LineBreak); err != nil {
+				return nil, err
 			}
 		} else {
 			// Write nothing if default section is empty
@@ -432,8 +427,8 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 		}
 
 		if sec.isRawSection {
-			if _, err = buf.WriteString(sec.rawBody); err != nil {
-				return 0, err
+			if _, err := buf.WriteString(sec.rawBody); err != nil {
+				return nil, err
 			}
 			continue
 		}
@@ -469,8 +464,8 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 				if key.Comment[0] != '#' && key.Comment[0] != ';' {
 					key.Comment = "; " + key.Comment
 				}
-				if _, err = buf.WriteString(key.Comment + LineBreak); err != nil {
-					return 0, err
+				if _, err := buf.WriteString(key.Comment + LineBreak); err != nil {
+					return nil, err
 				}
 			}
 
@@ -488,8 +483,8 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 			}
 
 			for _, val := range key.ValueWithShadows() {
-				if _, err = buf.WriteString(kname); err != nil {
-					return 0, err
+				if _, err := buf.WriteString(kname); err != nil {
+					return nil, err
 				}
 
 				if key.isBooleanType {
@@ -510,20 +505,31 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 				} else if !f.options.IgnoreInlineComment && strings.ContainsAny(val, "#;") {
 					val = "`" + val + "`"
 				}
-				if _, err = buf.WriteString(equalSign + val + LineBreak); err != nil {
-					return 0, err
+				if _, err := buf.WriteString(equalSign + val + LineBreak); err != nil {
+					return nil, err
 				}
 			}
 		}
 
 		if PrettySection {
 			// Put a line between sections
-			if _, err = buf.WriteString(LineBreak); err != nil {
-				return 0, err
+			if _, err := buf.WriteString(LineBreak); err != nil {
+				return nil, err
 			}
 		}
 	}
 
+	return buf, nil
+}
+
+// WriteToIndent writes content into io.Writer with given indention.
+// If PrettyFormat has been set to be true,
+// it will align "=" sign with spaces under each section.
+func (f *File) WriteToIndent(w io.Writer, indent string) (int64, error) {
+	buf, err := f.writeToBuffer(indent)
+	if err != nil {
+		return 0, err
+	}
 	return buf.WriteTo(w)
 }
 
@@ -536,23 +542,12 @@ func (f *File) WriteTo(w io.Writer) (int64, error) {
 func (f *File) SaveToIndent(filename, indent string) error {
 	// Note: Because we are truncating with os.Create,
 	// 	so it's safer to save to a temporary file location and rename afte done.
-	tmpPath := filename + "." + strconv.Itoa(time.Now().Nanosecond()) + ".tmp"
-	defer os.Remove(tmpPath)
-
-	fw, err := os.Create(tmpPath)
+	buf, err := f.writeToBuffer(indent)
 	if err != nil {
 		return err
 	}
 
-	if _, err = f.WriteToIndent(fw, indent); err != nil {
-		fw.Close()
-		return err
-	}
-	fw.Close()
-
-	// Remove old file and rename the new one.
-	os.Remove(filename)
-	return os.Rename(tmpPath, filename)
+	return ioutil.WriteFile(filename, buf.Bytes(), 0666)
 }
 
 // SaveTo writes content to file system.

--- a/vendor/gopkg.in/ini.v1/struct.go
+++ b/vendor/gopkg.in/ini.v1/struct.go
@@ -408,10 +408,11 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflectTime:
-		return v.Interface().(time.Time).IsZero()
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
+	case reflectTime:
+		t, ok := v.Interface().(time.Time)
+		return ok && t.IsZero()
 	}
 	return false
 }


### PR DESCRIPTION
Basic Auth; Follows haproxy ingress controller standard https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy HAProxy Ingress read user and password from auth file stored on secrets, one user and password per line.
Each line of the auth file should have: user and insecure password separated with a pair of colons: `<username>::<plain-text-passwd>`; or user and an encrypted password separated with colons: `<username>:<encrypted-passwd>` Secret name, realm and type are configured with annotations in the ingress
Auth can only be applied to HTTP backends.
```
// Only supported type is basic
AuthType = "ingress.kubernetes.io/auth-type"

// an optional string with authentication realm
AuthRealm = "ingress.kubernetes.io/auth-realm"

// name of the secret
AuthSecret = "ingress.kubernetes.io/auth-secret"
```
