### PR TITLE
Fix SG group name for GCE

### DIFF
--- a/api/validator.go
+++ b/api/validator.go
@@ -211,7 +211,7 @@ func (r Ingress) SupportsLBType(cloudProvider string) bool {
 		return cloudProvider != "acs"
 	case LBTypeHostPort:
 		// TODO: https://github.com/appscode/voyager/issues/374
-		return cloudProvider != "acs" && cloudProvider != "azure"
+		return cloudProvider != "acs" && cloudProvider != "azure" && cloudProvider != "gce" && cloudProvider != "gke"
 	default:
 		return false
 	}

--- a/third_party/forked/cloudprovider/cloud.go
+++ b/third_party/forked/cloudprovider/cloud.go
@@ -35,9 +35,9 @@ type Interface interface {
 
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
-func GetLoadBalancerName(service *apiv1.Service) string {
+func GetSecurityGroupName(service *apiv1.Service) string {
 	//GCE requires that the name of a load balancer starts with a lower case letter.
-	ret := service.Name + "@" + service.Namespace // "a" + string(service.UID)
+	ret := service.Name + "-" + service.Namespace // "a" + string(service.UID)
 	ret = strings.Replace(ret, "-", "", -1)
 	//AWS requires that the name of a load balancer is shorter than 32 bytes.
 	if len(ret) > 32 {

--- a/third_party/forked/cloudprovider/providers/azure/azure_util.go
+++ b/third_party/forked/cloudprovider/providers/azure/azure_util.go
@@ -49,7 +49,7 @@ func getServiceName(service *apiv1.Service) string {
 
 // This returns a prefix for loadbalancer/security rules.
 func getRulePrefix(service *apiv1.Service) string {
-	return cloudprovider.GetLoadBalancerName(service)
+	return cloudprovider.GetSecurityGroupName(service)
 }
 
 func serviceOwnsRule(service *apiv1.Service, rule string) bool {


### PR DESCRIPTION
```
No node tags supplied and also failed to parse the given lists of hosts for tags. Abort creating firewall rule.
Stack trace:
/go/src/github.com/appscode/voyager/pkg/operator/ingress_tprs.go:100                      (*Operator).AddEngress
/go/src/github.com/appscode/voyager/pkg/operator/ingress_tprs.go:52                       (*Operator).initIngressTPRWatcher.func3
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:192 ResourceEventHandlerFuncs.OnAdd
<autogenerated>:54                                                                        (*ResourceEventHandlerFuncs).OnAdd
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:270 NewInformer.func1
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:451 (*DeltaFIFO).Pop
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:147 (*controller).processLoop
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:121 processLoop)-fm
/go/src/github.com/appscode/voyager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:96   JitterUntil.func1
/go/src/github.com/appscode/voyager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:97   JitterUntil
/go/src/github.com/appscode/voyager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:52   Until
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:121 (*controller).Run
/usr/local/go/src/runtime/asm_amd64.s:2197                                                goexit
I0910 12:18:31.649632       1 gce.go:412] EnsureFirewall(voyager-test-ingress-default, us-central1, [TCP/80], [0xc420386410 0xc420386460], default/voyager-test-ingress)
I0910 12:18:31.946559       1 services.go:149] Loadbalancer update failed 
Caused By:
No node tags supplied and also failed to parse the given lists of hosts for tags. Abort creating firewall rule.
Stack trace:
/go/src/github.com/appscode/voyager/pkg/operator/services.go:147                          (*Operator).updateHAProxyConfig
/go/src/github.com/appscode/voyager/pkg/operator/services.go:38                           (*Operator).initServiceWatcher.func3
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:192 ResourceEventHandlerFuncs.OnAdd
<autogenerated>:54                                                                        (*ResourceEventHandlerFuncs).OnAdd
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:336 NewIndexerInformer.func1
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:451 (*DeltaFIFO).Pop
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:147 (*controller).processLoop
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:121 processLoop)-fm
/go/src/github.com/appscode/voyager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:96   JitterUntil.func1
/go/src/github.com/appscode/voyager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:97   JitterUntil
/go/src/github.com/appscode/voyager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:52   Until
/go/src/github.com/appscode/voyager/vendor/k8s.io/client-go/tools/cache/controller.go:121 (*controller).Run
/usr/local/go/src/runtime/asm_amd64.s:2197                                                goexit
```