### PR TITLE
Add support for `ingress.kubernetes.io/session-cookie-hash`.

### DIFF
--- a/apis/voyager/v1beta1/annotations.go
+++ b/apis/voyager/v1beta1/annotations.go
@@ -163,9 +163,14 @@ const (
 	// If applied to Service and Ingress do not have this annotation only
 	// connection to that backend service will be sticky.
 	// Deprecated
-	StickySession                    = EngressKey + "/" + "sticky-session"
-	IngressAffinity                  = IngressKey + "/affinity"
+	StickySession = EngressKey + "/" + "sticky-session"
+	// Specify a method to stick clients to origins across requests.
+	// Only supported value is cookie.
+	IngressAffinity = IngressKey + "/affinity"
+	// When affinity is set to cookie, the name of the cookie to use.
 	IngressAffinitySessionCookieName = IngressKey + "/session-cookie-name"
+	// When affinity is set to cookie, the hash algorithm used: md5, sha, index.
+	IngressAffinitySessionCookieHash = IngressKey + "/session-cookie-hash"
 
 	// Basic Auth: Follows ingress controller standard
 	// https://github.com/kubernetes/ingress/tree/master/examples/auth/basic/haproxy
@@ -233,6 +238,10 @@ func (r Ingress) StickySessionCookieName() string {
 		return cookieName
 	}
 	return "SERVERID"
+}
+
+func (r Ingress) StickySessionCookieHashType() string {
+	return GetString(r.Annotations, IngressAffinitySessionCookieHash)
 }
 
 func (r Ingress) Stats() bool {

--- a/hack/docker/voyager/templates/http-backend.cfg
+++ b/hack/docker/voyager/templates/http-backend.cfg
@@ -14,7 +14,7 @@ backend {{ $path.Backend.Name }}
 	http-request add-header {{ $rule }} unless ___header_x_{{ $index }}_exists
 	{{- end }}
 
-	{{- range $e := $path.Backend.Endpoints }}
+	{{- range $index, $e := $path.Backend.Endpoints }}
 	{{- if $e.ExternalName }}
 	{{- if $e.UseDNSResolver }}
 	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
@@ -22,7 +22,7 @@ backend {{ $path.Backend.Name }}
 	http-request redirect location {{ if $.UsesSSL }}https://{{ else }}http://{{ end }}{{$e.ExternalName}}:{{ $e.Port }} code 301
 	{{- end }}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end -}} {{ if $path.Backend.Sticky }} cookie {{ $e.Name }} {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end -}} {{ if $path.Backend.Sticky }} cookie {{ backend_hash $e.Name $index $path.Backend.StickyCookieHash }} {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{ end -}}
 	{{ end }}
 {{ end -}}

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -1,6 +1,10 @@
 package haproxy
 
 import (
+	"crypto/md5"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
 	"strings"
 	"text/template"
 )
@@ -28,10 +32,24 @@ func HostName(v string) string {
 	return "hdr(host) -i " + v
 }
 
+func BackendHash(value string, index int, mode string) string {
+	if mode == "md5" {
+		hash := md5.Sum([]byte(value))
+		return base64.StdEncoding.EncodeToString(hash[:])
+	} else if mode == "sha" {
+		hash := sha512.Sum512([]byte(value))
+		return base64.StdEncoding.EncodeToString(hash[:])
+	} else if mode == "index" {
+		return fmt.Sprintf("%d", index+1)
+	}
+	return value
+}
+
 var (
 	funcMap = template.FuncMap{
-		"header_name": HeaderName,
-		"host_name":   HostName,
+		"header_name":  HeaderName,
+		"host_name":    HostName,
+		"backend_hash": BackendHash,
 	}
 
 	haproxyTemplate *template.Template

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -87,6 +87,7 @@ type Backend struct {
 
 	Sticky           bool
 	StickyCookieName string
+	StickyCookieHash string
 }
 
 func (be *Backend) canonicalize() {

--- a/pkg/ingress/parser.go
+++ b/pkg/ingress/parser.go
@@ -150,6 +150,7 @@ func (c *controller) getEndpoints(s *apiv1.Service, servicePort *apiv1.ServicePo
 		Endpoints:        eps,
 		Sticky:           c.Ingress.Sticky() || isServiceSticky(s.Annotations),
 		StickyCookieName: c.Ingress.StickySessionCookieName(),
+		StickyCookieHash: c.Ingress.StickySessionCookieHashType(),
 	}, nil
 }
 
@@ -228,6 +229,7 @@ func (c *controller) generateConfig() error {
 			HeaderRules:      c.Ingress.Spec.Backend.HeaderRule,
 			Sticky:           bk.Sticky,
 			StickyCookieName: bk.StickyCookieName,
+			StickyCookieHash: bk.StickyCookieHash,
 		}
 	}
 
@@ -297,6 +299,7 @@ func (c *controller) generateConfig() error {
 							HeaderRules:      path.Backend.HeaderRule,
 							Sticky:           bk.Sticky,
 							StickyCookieName: bk.StickyCookieName,
+							StickyCookieHash: bk.StickyCookieHash,
 						},
 					})
 				}
@@ -351,6 +354,7 @@ func (c *controller) generateConfig() error {
 						Endpoints:        bk.Endpoints,
 						Sticky:           bk.Sticky,
 						StickyCookieName: bk.StickyCookieName,
+						StickyCookieHash: bk.StickyCookieHash,
 					},
 				}
 				if secretName, ok := c.Ingress.FindTLSSecret(rule.Host); ok && !rule.TCP.NoTLS {

--- a/test/e2e/ingress_ops.go
+++ b/test/e2e/ingress_ops.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -533,16 +532,13 @@ var _ = Describe("IngressOperations", func() {
 			ing.Annotations[api.IngressAffinitySessionCookieHash] = "md5"
 		})
 
-		FIt("Should Stick Session", func() {
+		It("Should Stick Session", func() {
 			By("Getting HTTP endpoints")
 			eps, err := f.Ingress.GetHTTPEndpoints(ing)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(eps)).Should(BeNumerically(">=", 1))
 
 			err = f.Ingress.DoHTTP(framework.MaxRetry, "", ing, eps, "GET", "/testpath/ok", func(r *testserverclient.Response) bool {
-
-				fmt.Println(">>>>", r.ResponseHeader)
-
 				return Expect(r.Status).Should(Equal(http.StatusOK)) &&
 					Expect(r.Method).Should(Equal("GET")) &&
 					Expect(r.Path).Should(Equal("/testpath/ok")) &&

--- a/test/e2e/ingress_ops.go
+++ b/test/e2e/ingress_ops.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -529,6 +530,7 @@ var _ = Describe("IngressOperations", func() {
 		BeforeEach(func() {
 			ing.Annotations[api.IngressAffinity] = "true"
 			ing.Annotations[api.IngressAffinitySessionCookieName] = "TEST-COOKIE_NAME"
+			ing.Annotations[api.IngressAffinitySessionCookieHash] = "md5"
 		})
 
 		FIt("Should Stick Session", func() {
@@ -538,6 +540,9 @@ var _ = Describe("IngressOperations", func() {
 			Expect(len(eps)).Should(BeNumerically(">=", 1))
 
 			err = f.Ingress.DoHTTP(framework.MaxRetry, "", ing, eps, "GET", "/testpath/ok", func(r *testserverclient.Response) bool {
+
+				fmt.Println(">>>>", r.ResponseHeader)
+
 				return Expect(r.Status).Should(Equal(http.StatusOK)) &&
 					Expect(r.Method).Should(Equal("GET")) &&
 					Expect(r.Path).Should(Equal("/testpath/ok")) &&


### PR DESCRIPTION
When affinity is set to cookie, the hash algorithm used: md5, sha, index.