### PR TITLE
Fix HSTS header template

### DIFF
--- a/hack/docker/voyager/templates/http-frontend.cfg
+++ b/hack/docker/voyager/templates/http-frontend.cfg
@@ -5,7 +5,7 @@ frontend {{ .FrontendName }}
 	rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure
 	{{- if .EnableHSTS }}
 	# Add the HSTS header with a 6 month default max-age
-	rspadd  Strict-Transport-Security:\ max-age={{ .HSTSMaxAge }}{{ if .HSTSPreload }}; preload{{ end }}{{if .HSTSIncludeSubDomains }}; includeSubDomains{{ end }}
+	rspadd  Strict-Transport-Security:\ max-age={{ .HSTSMaxAge }}{{ if .HSTSPreload }};\ preload{{ end }}{{if .HSTSIncludeSubDomains }};\ includeSubDomains{{ end }}
 	{{ end -}}
 	{{ else -}}
 	bind *:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }}


### PR DESCRIPTION
https://www.haproxy.com/blog/haproxy-and-http-strict-transport-security-hsts-header-in-http-redirects/