### PR TITLE
Remove UpdateRBAC mode.

### DIFF
--- a/pkg/ingress/hostport.go
+++ b/pkg/ingress/hostport.go
@@ -352,11 +352,6 @@ func (c *hostPortController) Update(mode UpdateMode, old *api.Ingress) error {
 			}
 		}
 	}
-
-	if mode&UpdateRBAC > 0 {
-		c.ensureRoles()
-	}
-
 	return nil
 }
 

--- a/pkg/ingress/loadbalancer.go
+++ b/pkg/ingress/loadbalancer.go
@@ -310,11 +310,6 @@ func (c *loadBalancerController) Update(mode UpdateMode, old *api.Ingress) error
 			}
 		}
 	}
-
-	if mode&UpdateRBAC > 0 {
-		c.ensureRoles()
-	}
-
 	return nil
 }
 

--- a/pkg/ingress/nodeport.go
+++ b/pkg/ingress/nodeport.go
@@ -374,11 +374,6 @@ func (c *nodePortController) Update(mode UpdateMode, old *api.Ingress) error {
 			}
 		}
 	}
-
-	if mode&UpdateRBAC > 0 {
-		c.ensureRoles()
-	}
-
 	return nil
 }
 

--- a/pkg/ingress/update.go
+++ b/pkg/ingress/update.go
@@ -16,7 +16,6 @@ type UpdateMode int
 
 const (
 	UpdateStats UpdateMode = 1 << iota // Update things for stats update
-	UpdateRBAC                         // Update RBAC Roles as stats secret name is changes
 )
 
 func (c *controller) updateConfigMap() error {

--- a/pkg/operator/ingress_crds.go
+++ b/pkg/operator/ingress_crds.go
@@ -126,12 +126,8 @@ func (op *Operator) UpdateEngress(oldEngress, newEngress *tapi.Ingress) {
 	} else {
 		if ctrl.IsExists() {
 			var updateMode ingress.UpdateMode
-
 			if oldEngress.IsStatsChanged(*newEngress) {
 				updateMode |= ingress.UpdateStats
-				if oldEngress.IsStatsSecretChanged(*newEngress) {
-					updateMode |= ingress.UpdateRBAC
-				}
 			}
 			// Check for changes in ingress.appscode.com/monitoring-agent
 			if newMonSpec, newErr := newEngress.MonitorSpec(); newErr == nil {


### PR DESCRIPTION
This is not needed anymore since HAProxy deployments watch all secrets in its namespace.