### PR TITLE
Allow for binding HTTP or TCP ingress rules to specific addresses

### DIFF
--- a/apis/voyager/ingress.go
+++ b/apis/voyager/ingress.go
@@ -181,6 +181,9 @@ type IngressRuleValue struct {
 // to match against everything after the last '/' and before the first '?'
 // or '#'.
 type HTTPIngressRuleValue struct {
+	// The network address to listen HTTP(s) connections on.
+	Address string `json:"address,omitempty"`
+
 	// port to listen http(s) connections.
 	Port intstr.IntOrString `json:"port,omitempty"`
 
@@ -195,6 +198,9 @@ type HTTPIngressRuleValue struct {
 }
 
 type TCPIngressRuleValue struct {
+	// The network address to listen HTTP(s) connections on.
+	Address string `json:"address,omitempty"`
+
 	// port to listen tcp connections.
 	Port intstr.IntOrString `json:"port,omitempty"`
 

--- a/apis/voyager/v1beta1/ingress.go
+++ b/apis/voyager/v1beta1/ingress.go
@@ -182,6 +182,9 @@ type IngressRuleValue struct {
 // to match against everything after the last '/' and before the first '?'
 // or '#'.
 type HTTPIngressRuleValue struct {
+	// The network address to listen HTTP(s) connections on.
+	Address string `json:"address,omitempty"`
+
 	// port to listen http(s) connections.
 	Port intstr.IntOrString `json:"port,omitempty"`
 
@@ -196,6 +199,9 @@ type HTTPIngressRuleValue struct {
 }
 
 type TCPIngressRuleValue struct {
+	// The network address to listen TCP connections on.
+	Address string `json:"address,omitempty"`
+
 	// port to listen tcp connections.
 	Port intstr.IntOrString `json:"port,omitempty"`
 

--- a/apis/voyager/v1beta1/zz_generated.conversion.go
+++ b/apis/voyager/v1beta1/zz_generated.conversion.go
@@ -530,6 +530,7 @@ func Convert_voyager_HTTPIngressPath_To_v1beta1_HTTPIngressPath(in *voyager.HTTP
 }
 
 func autoConvert_v1beta1_HTTPIngressRuleValue_To_voyager_HTTPIngressRuleValue(in *HTTPIngressRuleValue, out *voyager.HTTPIngressRuleValue, s conversion.Scope) error {
+	out.Address = in.Address
 	out.Port = in.Port
 	out.NoTLS = in.NoTLS
 	out.NodePort = in.NodePort
@@ -543,6 +544,7 @@ func Convert_v1beta1_HTTPIngressRuleValue_To_voyager_HTTPIngressRuleValue(in *HT
 }
 
 func autoConvert_voyager_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *voyager.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
+	out.Address = in.Address
 	out.Port = in.Port
 	out.NoTLS = in.NoTLS
 	out.NodePort = in.NodePort
@@ -816,6 +818,7 @@ func Convert_voyager_LocalTypedReference_To_v1beta1_LocalTypedReference(in *voya
 }
 
 func autoConvert_v1beta1_TCPIngressRuleValue_To_voyager_TCPIngressRuleValue(in *TCPIngressRuleValue, out *voyager.TCPIngressRuleValue, s conversion.Scope) error {
+	out.Address = in.Address
 	out.Port = in.Port
 	out.NoTLS = in.NoTLS
 	out.NodePort = in.NodePort
@@ -832,6 +835,7 @@ func Convert_v1beta1_TCPIngressRuleValue_To_voyager_TCPIngressRuleValue(in *TCPI
 }
 
 func autoConvert_voyager_TCPIngressRuleValue_To_v1beta1_TCPIngressRuleValue(in *voyager.TCPIngressRuleValue, out *TCPIngressRuleValue, s conversion.Scope) error {
+	out.Address = in.Address
 	out.Port = in.Port
 	out.NoTLS = in.NoTLS
 	out.NodePort = in.NodePort

--- a/hack/docker/voyager/templates/http-frontend.cfg
+++ b/hack/docker/voyager/templates/http-frontend.cfg
@@ -1,6 +1,6 @@
 frontend {{ .FrontendName }}
 	{{ if .OffloadSSL }}
-	bind *:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/tls/ {{ if .TLSAuth }} ca-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CAFile }} {{ if .TLSAuth.CRLFile }} crl-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CRLFile }}{{ end }} verify {{ .TLSAuth.VerifyClient }} {{ if .TLSAuth.ErrorPage }}crt-ignore-err all {{end}}{{ end }} alpn http/1.1
+	bind {{ .Address }}:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }} ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/tls/ {{ if .TLSAuth }} ca-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CAFile }} {{ if .TLSAuth.CRLFile }} crl-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CRLFile }}{{ end }} verify {{ .TLSAuth.VerifyClient }} {{ if .TLSAuth.ErrorPage }}crt-ignore-err all {{end}}{{ end }} alpn http/1.1
 	# Mark all cookies as secure
 	rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure
 	{{ if .EnableHSTS }}
@@ -8,7 +8,7 @@ frontend {{ .FrontendName }}
 	rspadd  Strict-Transport-Security:\ max-age={{ .HSTSMaxAge }}{{ if .HSTSPreload }};\ preload{{ end }}{{ if .HSTSIncludeSubDomains }};\ includeSubDomains{{ end }}
 	{{ end }}
 	{{ else }}
-	bind *:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }}
+	bind {{ .Address }}:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }}
 	{{ end }}
 
 	mode http

--- a/hack/docker/voyager/templates/tcp-frontend.cfg
+++ b/hack/docker/voyager/templates/tcp-frontend.cfg
@@ -1,5 +1,5 @@
 frontend {{ .FrontendName }}
-	bind *:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }} {{ if .CertFile }}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/tls/{{ .CertFile }} {{ end }} {{ if .TLSAuth }} ca-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CAFile }} {{ if .TLSAuth.CRLFile }} crl-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CRLFile }}{{ end }} verify {{ .TLSAuth.VerifyClient }}{{ end }} {{ if .ALPNOptions }}{{ .ALPNOptions }}{{ end }}
+	bind {{ .Address }}:{{ .Port }} {{ if .AcceptProxy }}accept-proxy{{ end }} {{ if .CertFile }}ssl no-sslv3 no-tlsv10 no-tls-tickets crt /etc/ssl/private/haproxy/tls/{{ .CertFile }} {{ end }} {{ if .TLSAuth }} ca-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CAFile }} {{ if .TLSAuth.CRLFile }} crl-file /etc/ssl/private/haproxy/ca/{{ .TLSAuth.CRLFile }}{{ end }} verify {{ .TLSAuth.VerifyClient }}{{ end }} {{ if .ALPNOptions }}{{ .ALPNOptions }}{{ end }}
 	mode tcp
 
 	{{- if .Limit }}

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -53,6 +53,7 @@ type HTTPService struct {
 	*SharedInfo
 
 	FrontendName  string
+	Address       string
 	Port          int
 	NodePort      int32
 	OffloadSSL    bool
@@ -89,6 +90,7 @@ type TCPService struct {
 	*SharedInfo
 
 	FrontendName  string
+	Address       string
 	Host          string
 	Port          string
 	FrontendRules []string


### PR DESCRIPTION
Currently, Voyager will allow (or enforce, in the case of TCP rules) specifying a specific port to
expose services against, regardless of their internal service port. This commit extends this
functionality by allowing for specifying an optional bind address (IPv4 or IPv6), which defaults to
a wildcard ('*'), which binds to all available addresses.

An example 'Ingress' definition might look like:

```
apiVersion: voyager.appscode.com/v1beta1
kind: Ingress
metadata:
  name: ingress
  namespace: default
  labels:
	app: voyager
  annotations:
	ingress.appscode.com/type: HostPort
spec:
  rules:
	- host: deuill.org
	  http:
		address: 203.0.113.101
		paths:
		  - backend:
			  serviceName: deuill.web
			  servicePort: 80
	- host: mail.deuill.org
	  tcp:
		address: 203.0.113.102
		port: 25
		backend:
		  serviceName: postfix.mail
		  servicePort: 25
```

Noted that wildcard and non-wildcard rules cannot be mixed for the same external port number, due to
how the underlying HAProxy configuration is set up. This essentially means that, if you have a
single HTTP host binding to a specific address, all other HTTP hosts must specify an address as
well.