### PR TITLE
Enable server health check using service annotations and backend rules

### DIFF
--- a/apis/voyager/v1beta1/annotations.go
+++ b/apis/voyager/v1beta1/annotations.go
@@ -235,6 +235,11 @@ const (
 	// http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#7.3.3-src_conn_cur
 	// https://www.haproxy.com/blog/use-a-load-balancer-as-a-first-row-of-defense-against-ddos/
 	LimitConnection = IngressKey + "/limit-connection"
+
+	// https://github.com/appscode/voyager/issues/683
+	// https://www.haproxy.com/documentation/aloha/7-0/haproxy/healthchecks/
+	CheckHealth     = EngressKey + "/" + "check"
+	CheckHealthPort = EngressKey + "/" + "check-port"
 )
 
 const (

--- a/hack/docker/voyager/templates/default-backend.cfg
+++ b/hack/docker/voyager/templates/default-backend.cfg
@@ -23,13 +23,13 @@ backend {{ .DefaultBackend.Name }}
 	{{- range $e := .DefaultBackend.Endpoints }}
 	{{- if $e.ExternalName }}
 	{{- if $e.UseDNSResolver }}
-	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{- if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{- end }} {{- end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{- else if not $.DefaultBackend.BackendRules }}
 	acl https ssl_fc
 	http-request redirect location https://{{$e.ExternalName}}:{{ $e.Port }} code 301 if https
 	http-request redirect location http://{{$e.ExternalName}}:{{ $e.Port }} code 301 unless https
 	{{ end -}}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $.DefaultBackend.Sticky }} cookie {{ $e.Name }}{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $.DefaultBackend.Sticky }} cookie {{ $e.Name }}{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}} {{ if $e.CheckHealth }} check {{- if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{- end }} {{- end }}
 	{{ end -}}
 	{{ end -}}

--- a/hack/docker/voyager/templates/http-backend.cfg
+++ b/hack/docker/voyager/templates/http-backend.cfg
@@ -25,12 +25,12 @@ backend {{ $path.Backend.Name }}
 	{{- range $index, $e := $path.Backend.Endpoints }}
 	{{- if $e.ExternalName }}
 	{{- if $e.UseDNSResolver }}
-	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{- if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{- end }} {{- end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4 {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{- else if not $path.Backend.BackendRules }}
 	http-request redirect location {{ if $.OffloadSSL }}https://{{ else }}http://{{ end }}{{$e.ExternalName}}:{{ $e.Port }} code 301
 	{{- end }}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end -}} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end -}} {{ if $path.Backend.Sticky }} cookie {{ backend_hash $e.Name $index $path.Backend.StickyCookieHash }} {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end -}} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end -}} {{ if $path.Backend.Sticky }} cookie {{ backend_hash $e.Name $index $path.Backend.StickyCookieHash }} {{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}} {{ if $e.CheckHealth }} check {{- if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{- end }} {{- end }}
 	{{ end -}}
 	{{ end }}
 {{ end -}}

--- a/hack/docker/voyager/templates/tcp-backend.cfg
+++ b/hack/docker/voyager/templates/tcp-backend.cfg
@@ -12,8 +12,8 @@ backend {{ .Backend.Name }}
 
 	{{- range $e := .Backend.Endpoints }}
 	{{- if $e.ExternalName }}
-	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check{{ end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.ExternalName }}:{{ $e.Port -}} {{ if $e.DNSResolver }} {{ if $e.CheckHealth }} check {{- if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{- end }} {{- end }} resolvers {{ $e.DNSResolver }} resolve-prefer ipv4{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
 	{{- else }}
-	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}}
+	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port -}} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end -}} {{ if $e.Weight }} weight {{ $e.Weight }}{{ end -}} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end -}} {{ if $e.CheckHealth }} check {{- if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{- end }} {{- end }}
 	{{ end -}}
 	{{ end -}}

--- a/pkg/haproxy/template_test.go
+++ b/pkg/haproxy/template_test.go
@@ -416,22 +416,17 @@ func TestTemplateAuth(t *testing.T) {
 				{Name: "first", IP: "10.244.2.2", Port: "2324"},
 			},
 		},
-		BasicAuth: &BasicAuth{
-			Realm: "Required",
-			Users: map[string][]AuthUser{
-				"auth": {
-					{
-						Username:  "foo",
-						Password:  "#bar",
-						Encrypted: true,
-					},
-					{
-						Username:  "foo2",
-						Password:  "bar2",
-						Encrypted: false,
-					},
-				},
-				"auth2": {
+	}
+	testParsedConfig := TemplateData{
+		SharedInfo: si,
+		TimeoutDefaults: map[string]string{
+			"client": "2s",
+			"fin":    "1d",
+		},
+		UserLists: []UserList{
+			{
+				Name: "auth",
+				Users: []AuthUser{
 					{
 						Username:  "foo",
 						Password:  "#bar",
@@ -444,13 +439,21 @@ func TestTemplateAuth(t *testing.T) {
 					},
 				},
 			},
-		},
-	}
-	testParsedConfig := TemplateData{
-		SharedInfo: si,
-		TimeoutDefaults: map[string]string{
-			"client": "2s",
-			"fin":    "1d",
+			{
+				Name: "auth2",
+				Users: []AuthUser{
+					{
+						Username:  "foo",
+						Password:  "#bar",
+						Encrypted: true,
+					},
+					{
+						Username:  "foo2",
+						Password:  "bar2",
+						Encrypted: false,
+					},
+				},
+			},
 		},
 		HTTPService: []*HTTPService{
 			{
@@ -536,21 +539,8 @@ func TestTemplateServiceAuth(t *testing.T) {
 				{Name: "first", IP: "10.244.2.2", Port: "2324"},
 			},
 			BasicAuth: &BasicAuth{
-				Realm: "Required",
-				Users: map[string][]AuthUser{
-					"auth": {
-						{
-							Username:  "foo",
-							Password:  "#bar",
-							Encrypted: true,
-						},
-						{
-							Username:  "foo2",
-							Password:  "bar2",
-							Encrypted: false,
-						},
-					},
-				},
+				Realm:     "Required",
+				UserLists: []string{"auth"},
 			},
 		},
 	}
@@ -572,21 +562,8 @@ func TestTemplateServiceAuth(t *testing.T) {
 								{Name: "first", IP: "10.244.2.2", Port: "2324"},
 							},
 							BasicAuth: &BasicAuth{
-								Realm: "Required",
-								Users: map[string][]AuthUser{
-									"auth-2": {
-										{
-											Username:  "foo",
-											Password:  "#bar",
-											Encrypted: true,
-										},
-										{
-											Username:  "foo2",
-											Password:  "bar2",
-											Encrypted: false,
-										},
-									},
-								},
+								Realm:     "Required",
+								UserLists: []string{"auth2"},
 							},
 						},
 					},

--- a/pkg/haproxy/types.go
+++ b/pkg/haproxy/types.go
@@ -127,15 +127,16 @@ func (be *Backend) canonicalize() {
 }
 
 type Endpoint struct {
-	Name           string
-	IP             string
-	Port           string
-	Weight         int
-	MaxConnections int
-	ExternalName   string
-	UseDNSResolver bool
-	DNSResolver    string
-	CheckHealth    bool
+	Name            string
+	IP              string
+	Port            string
+	Weight          int
+	MaxConnections  int
+	ExternalName    string
+	UseDNSResolver  bool
+	DNSResolver     string
+	CheckHealth     bool
+	CheckHealthPort string
 
 	TLSOption string
 }

--- a/pkg/ingress/parser.go
+++ b/pkg/ingress/parser.go
@@ -143,6 +143,10 @@ func (c *controller) getEndpoints(svc *core.Service, servicePort *core.ServicePo
 
 					if svc.Annotations != nil {
 						ep.TLSOption = svc.Annotations[api.BackendTLSOptions]
+						if svc.Annotations[api.CheckHealth] == "true" {
+							ep.CheckHealth = true
+							ep.CheckHealthPort = svc.Annotations[api.CheckHealthPort]
+						}
 					}
 
 					eps = append(eps, ep)

--- a/test/framework/ingress_util.go
+++ b/test/framework/ingress_util.go
@@ -1054,3 +1054,80 @@ func (i *ingressInvocation) CreateResourceWithServiceAuth(secret *core.Secret) (
 
 	return meta, nil
 }
+
+func (i *ingressInvocation) CreateResourceWithServiceAnnotation(svcAnnotation map[string]string) (metav1.ObjectMeta, error) {
+	meta := metav1.ObjectMeta{
+		Name:        i.UniqueName(),
+		Namespace:   i.Namespace(),
+		Annotations: svcAnnotation,
+	}
+	_, err := i.KubeClient.CoreV1().Services(i.Namespace()).Create(&core.Service{
+		ObjectMeta: meta,
+		Spec: core.ServiceSpec{
+			Ports: []core.ServicePort{
+				{
+					Name:       "http-1",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					Protocol:   "TCP",
+				},
+			},
+			Selector: map[string]string{
+				"app": meta.Name,
+			},
+		},
+	})
+	if err != nil {
+		return meta, err
+	}
+
+	_, err = i.KubeClient.ExtensionsV1beta1().Deployments(i.Namespace()).Create(&extensions.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dep-1-" + meta.Name,
+			Namespace: meta.Namespace,
+		},
+		Spec: extensions.DeploymentSpec{
+			Replicas: types.Int32P(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":         meta.Name,
+					"app-version": "v1",
+				},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":         meta.Name,
+						"app-version": "v1",
+					},
+				},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name:  "server",
+							Image: "appscode/test-server:2.2",
+							Env: []core.EnvVar{
+								{
+									Name: "POD_NAME",
+									ValueFrom: &core.EnvVarSource{
+										FieldRef: &core.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+							},
+							Ports: []core.ContainerPort{
+								{
+									Name:          "http-1",
+									ContainerPort: 8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	return meta, err
+}


### PR DESCRIPTION
Fixed #683 

Service annotations:
```
ingress.appscode.com/check: "true"
ingress.appscode.com/check-port: "5050"
```
Backend rules: 
https://github.com/appscode/voyager/blob/master/docs/user-guide/ingress/backend-rule.md
```
backendRule:
- 'option httpchk GET /testpath/ok'
- 'http-check expect rstring (testpath/ok)'
```