### PR TITLE
Don't use backend name to generate acl name

### DIFF
--- a/hack/docker/voyager/templates/http-backend.cfg
+++ b/hack/docker/voyager/templates/http-backend.cfg
@@ -1,5 +1,5 @@
 {{ range $path := .Paths }}
-
+{{ if $path.Backend.Name }}
 backend {{ $path.Backend.Name }}
 	{{ if $path.Backend.BasicAuth }}
 	{{ range $name := $path.Backend.BasicAuth.UserLists }}
@@ -32,4 +32,5 @@ backend {{ $path.Backend.Name }}
 	server {{ $e.Name }} {{ $e.IP }}:{{ $e.Port }} {{ if $e.MaxConnections }} maxconn {{ $e.MaxConnections }} {{ end }} {{ if $e.Weight }} weight {{ $e.Weight }} {{ end }} {{ if $path.Backend.Sticky }} cookie {{ backend_hash $e.Name $index $path.Backend.StickyCookieHash }} {{ end }} {{ if $e.TLSOption }} {{ $e.TLSOption }} {{ end }} {{ if $e.CheckHealth }} check {{ if $e.CheckHealthPort }} port {{ $e.CheckHealthPort }} {{ end }} {{ end }} {{ if $e.SendProxy }}{{ $e.SendProxy }}{{ end }}
 	{{ end }}
 	{{ end }}
+{{ end }}
 {{ end }}

--- a/hack/docker/voyager/templates/http-frontend.cfg
+++ b/hack/docker/voyager/templates/http-frontend.cfg
@@ -74,14 +74,15 @@ frontend {{ .FrontendName }}
 
 	{{ range $path := .Paths }}
 	{{ if  and (or (eq $.Port 80) (eq $.Port 443)) ( or $.ForceMatchServicePort (not $.NodePort)) }}
-	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ end }}
+	{{ if $path.Host }}acl host_acl_{{ $path.Host | acl_name }} {{ $path.Host | host_name }}{{ end }}
 	{{ end }}
-	{{ if $path.Host }}acl host_acl_{{ $path.Backend.Name }} {{ $path.Host | host_name }}{{ if and (not $.ForceMatchServicePort) $.NodePort }}:{{ $.NodePort }}{{ else }}:{{ $.Port }}{{ end }}{{ end }}
-	{{ if $path.Path }}acl url_acl_{{ $path.Backend.Name }} path_beg {{ $path.Path }}{{ end }}
+	{{ if $path.Host }}acl host_acl_{{ $path.Host | acl_name }} {{ $path.Host | host_name }}{{ if and (not $.ForceMatchServicePort) $.NodePort }}:{{ $.NodePort }}{{ else }}:{{ $.Port }}{{ end }}{{ end }}
+	{{ if $path.Path }}acl url_acl_{{ $path.Host | acl_name }}_{{ $path.Path | acl_name }} path_beg {{ $path.Path }}{{ end }}
 	{{ if $path.SSLRedirect }}
-	redirect scheme https code 301 if ! is_proxy_https {{ if $path.Host }}host_acl_{{ $path.Backend.Name }}{{ end }}{{ if $path.Path }} url_acl_{{ $path.Backend.Name }}{{ end }}
+	redirect scheme https code 301 if ! is_proxy_https {{ if $path.Host }}host_acl_{{ $path.Host | acl_name }}{{ end }}{{ if $path.Path }} url_acl_{{ $path.Host | acl_name }}_{{ $path.Path | acl_name }}{{ end }}
+	{{ else }}
+	use_backend {{ $path.Backend.Name }} {{ if or $path.Host $path.Path }}if {{ end }}{{ if $path.Host }}host_acl_{{ $path.Host | acl_name }}{{ end }}{{ if $path.Path }} url_acl_{{ $path.Host | acl_name }}_{{ $path.Path | acl_name }}{{ end }}
 	{{ end }}
-	use_backend {{ $path.Backend.Name }} {{ if or $path.Host $path.Path }}if {{ end }}{{ if $path.Host }}host_acl_{{ $path.Backend.Name }}{{ end }}{{ if $path.Path }} url_acl_{{ $path.Backend.Name }}{{ end }}
 	{{ end }}
 	{{ if .DefaultBackend }}
 	default_backend {{ .DefaultBackend.Name }}

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -9,6 +9,19 @@ import (
 	"text/template"
 )
 
+/*
+<aclname>: name of the acl, usually tries to describe it as much as possible.
+
+It must be formed from upper and lower case letters, digits, ‘-‘ (dash), ‘_’ (underscore) , ‘.’ (dot) and ‘:’ (colon).
+It is case sensitive, so my_acl and My_Acl are two different ACLs.
+
+ref: https://www.haproxy.com/documentation/aloha/7-0/haproxy/acls/
+*/
+func ACLName(v string) string {
+	v = strings.Replace(v, "/", "_", -1)
+	return v
+}
+
 func HeaderName(v string) string {
 	v = strings.TrimSpace(v)
 	if v == "" {
@@ -47,6 +60,7 @@ func BackendHash(value string, index int, mode string) string {
 
 var (
 	funcMap = template.FuncMap{
+		"acl_name":  ACLName,
 		"header_name":  HeaderName,
 		"host_name":    HostName,
 		"backend_hash": BackendHash,

--- a/pkg/haproxy/template.go
+++ b/pkg/haproxy/template.go
@@ -60,7 +60,7 @@ func BackendHash(value string, index int, mode string) string {
 
 var (
 	funcMap = template.FuncMap{
-		"acl_name":  ACLName,
+		"acl_name":     ACLName,
 		"header_name":  HeaderName,
 		"host_name":    HostName,
 		"backend_hash": BackendHash,


### PR DESCRIPTION
ref:
https://www.haproxy.com/documentation/aloha/7-0/haproxy/acls/

Backend names are empty for paths that are auto injected for redirect rules. So, we can't assume that backend names will always be present.