### PR TITLE
Add aliases for README file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ section_menu_id: getting-started
 url: /products/voyager/5.0.0-rc.4/getting-started/
 aliases:
   - /products/voyager/5.0.0-rc.4/
+  - /products/voyager/5.0.0-rc.4/README/
 ---
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/appscode/voyager)](https://goreportcard.com/report/github.com/appscode/voyager)

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -11,6 +11,8 @@ product_name: voyager
 left_menu: product_voyager_5.0.0-rc.4
 section_menu_id: developer-guide
 url: /products/voyager/5.0.0-rc.4/developer-guide/
+aliases:
+  - /products/voyager/5.0.0-rc.4/developer-guide/README/
 ---
 
 ## Development Guide

--- a/docs/user-guide/certificate/README.md
+++ b/docs/user-guide/certificate/README.md
@@ -9,6 +9,8 @@ product_name: voyager
 left_menu: product_voyager_5.0.0-rc.4
 section_menu_id: user-guide
 url: /products/voyager/5.0.0-rc.4/user-guide/certificate/
+aliases:
+  - /products/voyager/5.0.0-rc.4/user-guide/certificate/README/
 ---
 
 ## Certificates

--- a/docs/user-guide/ingress/README.md
+++ b/docs/user-guide/ingress/README.md
@@ -8,6 +8,8 @@ product_name: voyager
 left_menu: product_voyager_5.0.0-rc.4
 section_menu_id: user-guide
 url: /products/voyager/5.0.0-rc.4/user-guide/ingress/
+aliases:
+  - /products/voyager/5.0.0-rc.4/user-guide/ingress/README/
 ---
 
 ### Ingress


### PR DESCRIPTION
Need this aliases otherwise following links will not work mentioned in /docs/README.md

- https://github.com/appscode/voyager/blob/master/docs/developer-guide/README.md
- https://github.com/appscode/voyager/blob/master/docs/CONTRIBUTING.md