### PR TITLE
Updating kube-mon so service-monitor-endpoint-port is optional

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: eac2079579d02a428a46bb2976ea1504d7472ba2284b529c06f3be74d002ae20
-updated: 2018-01-28T08:18:28.966943826-08:00
+updated: 2018-01-28T08:51:01.30361834-08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -30,7 +30,7 @@ imports:
   subpackages:
   - exporter
 - name: github.com/appscode/kube-mon
-  version: 81a498f54c6393864701ea3edc6442d1bc92aa54
+  version: 6c843f8c6418d421ec6e7d62d7840b114e043334
   subpackages:
   - agents
   - agents/coreosprometheusoperator

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: eac2079579d02a428a46bb2976ea1504d7472ba2284b529c06f3be74d002ae20
-updated: 2018-01-28T07:43:58.13580171-08:00
+updated: 2018-01-28T08:18:28.966943826-08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -144,7 +144,7 @@ imports:
 - name: github.com/dgrijalva/jwt-go
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/dnsimple/dnsimple-go
-  version: 4618db489ff90331782dd0a6cf3aa0de68415355
+  version: b43ddd3df165b3077b9f29bd1582280579325b56
   subpackages:
   - dnsimple
 - name: github.com/elazarl/go-bindata-assetfs

--- a/vendor/github.com/appscode/kube-mon/agents/agents.go
+++ b/vendor/github.com/appscode/kube-mon/agents/agents.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func New(t api.AgentType, k8sClient kubernetes.Interface, extClient ecs.ApiextensionsV1beta1Interface, promClient prom.MonitoringV1Interface) api.Agent {
-	switch t {
-	case api.AgentCoreOSPrometheus:
-		return coreosprometheusoperator.New(k8sClient, extClient, promClient)
+func New(at api.AgentType, k8sClient kubernetes.Interface, extClient ecs.ApiextensionsV1beta1Interface, promClient prom.MonitoringV1Interface) api.Agent {
+	switch at {
+	case api.AgentCoreOSPrometheus, api.DeprecatedAgentCoreOSPrometheus:
+		return coreosprometheusoperator.New(at, k8sClient, extClient, promClient)
 	case api.AgentPrometheusBuiltin:
 		return prometheusbuiltin.New(k8sClient)
 	}

--- a/vendor/github.com/appscode/kube-mon/agents/coreosprometheusoperator/lib.go
+++ b/vendor/github.com/appscode/kube-mon/agents/coreosprometheusoperator/lib.go
@@ -16,13 +16,15 @@ import (
 
 // PrometheusCoreosOperator creates `ServiceMonitor` so that CoreOS Prometheus operator can generate necessary config for Prometheus.
 type PrometheusCoreosOperator struct {
+	at api.AgentType
 	k8sClient  kubernetes.Interface
 	promClient prom.MonitoringV1Interface
 	extClient  ecs.ApiextensionsV1beta1Interface
 }
 
-func New(k8sClient kubernetes.Interface, extClient ecs.ApiextensionsV1beta1Interface, promClient prom.MonitoringV1Interface) api.Agent {
+func New(at api.AgentType, k8sClient kubernetes.Interface, extClient ecs.ApiextensionsV1beta1Interface, promClient prom.MonitoringV1Interface) api.Agent {
 	return &PrometheusCoreosOperator{
+		at:at,
 		k8sClient:  k8sClient,
 		extClient:  extClient,
 		promClient: promClient,
@@ -30,7 +32,7 @@ func New(k8sClient kubernetes.Interface, extClient ecs.ApiextensionsV1beta1Inter
 }
 
 func (agent *PrometheusCoreosOperator) GetType() api.AgentType {
-	return api.AgentCoreOSPrometheus
+	return agent.at
 }
 
 func (agent *PrometheusCoreosOperator) CreateOrUpdate(sp api.StatsAccessor, new *api.AgentSpec) (kutil.VerbType, error) {

--- a/vendor/github.com/appscode/kube-mon/api/types.go
+++ b/vendor/github.com/appscode/kube-mon/api/types.go
@@ -12,12 +12,17 @@ const (
 	KeyAgent   = "monitoring.appscode.com/agent"
 	KeyService = "monitoring.appscode.com/service"
 
-	VendorPrometheus                 = "prometheus.io"
-	AgentPrometheusBuiltin AgentType = VendorPrometheus + "/builtin"
-	AgentCoreOSPrometheus  AgentType = VendorPrometheus + "/coreos-operator"
+	VendorPrometheus                          = "prometheus.io"
+	AgentPrometheusBuiltin          AgentType = VendorPrometheus + "/builtin"
+	AgentCoreOSPrometheus           AgentType = VendorPrometheus + "/coreos-operator"
+	// Deprecated
+	DeprecatedAgentCoreOSPrometheus AgentType = "coreos-prometheus-operator"
 )
 
 func (at AgentType) Vendor() string {
+	if at == DeprecatedAgentCoreOSPrometheus {
+		return VendorPrometheus
+	}
 	return strings.SplitN(string(at), "/", 2)[0]
 }
 

--- a/vendor/github.com/appscode/kube-mon/parser.go
+++ b/vendor/github.com/appscode/kube-mon/parser.go
@@ -27,7 +27,7 @@ func Parse(annotations map[string]string, keyPrefix string, defaultExporterPort 
 	var err error
 
 	switch agent {
-	case api.AgentCoreOSPrometheus:
+	case api.AgentCoreOSPrometheus, api.DeprecatedAgentCoreOSPrometheus:
 		var prom api.PrometheusSpec
 
 		prom.Namespace, _ = meta.GetString(annotations, path.Join(keyPrefix, serviceMonitorNamespace))


### PR DESCRIPTION
This PR updates kube-mon. It fixes the scenario where we don't set service-monitor-endpoint-port annotation and it should fallback to default exporter port. 

What happens currently is that if service-monitor-endpoint-port annotation is not defined it will successfully create the ServiceMonitor and the the *-stats service but it does not add the port named 'http' to the service definition so the endpoints available won't match the job definition in prometheus and it does not add the sidecar container to the deployment spec either.