### PR TITLE
Preserve original HTTP verb on redirect

### DIFF
--- a/hack/docker/voyager/templates/http-frontend.cfg
+++ b/hack/docker/voyager/templates/http-frontend.cfg
@@ -80,7 +80,7 @@ frontend {{ .FrontendName }}
 	{{ range $path := $host.Paths }}
 	{{ if $path.Path }}acl url_acl_{{ $host.Host | acl_name }}_{{ $path.Path | acl_name }} path_beg {{ $path.Path }}{{ end }}
 	{{ if $path.SSLRedirect }}
-	redirect scheme https code 301 if ! is_proxy_https {{ if $host.Host }}host_acl_{{ $host.Host | acl_name }}{{ end }}{{ if $path.Path }} url_acl_{{ $host.Host | acl_name }}_{{ $path.Path | acl_name }}{{ end }}
+	redirect scheme https code 308 if ! is_proxy_https {{ if $host.Host }}host_acl_{{ $host.Host | acl_name }}{{ end }}{{ if $path.Path }} url_acl_{{ $host.Host | acl_name }}_{{ $path.Path | acl_name }}{{ end }}
 	{{ end }}
 	{{ if $path.Backend }}
 	use_backend {{ $path.Backend.Name }} {{ if or $host.Host $path.Path }}if {{ end }}{{ if $host.Host }}host_acl_{{ $host.Host | acl_name }}{{ end }}{{ if $path.Path }} url_acl_{{ $host.Host | acl_name }}_{{ $path.Path | acl_name }}{{ end }}


### PR DESCRIPTION
ref: https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-redirection/

Fixes #816