### PR TITLE
Use service port by default for LB type nodeport

### DIFF
--- a/apis/voyager/v1beta1/annotations.go
+++ b/apis/voyager/v1beta1/annotations.go
@@ -221,7 +221,7 @@ const (
 	MaxConnections       = EngressKey + "/max-connections"
 
 	// https://github.com/appscode/voyager/issues/552
-	ForceServicePort = EngressKey + "/force-service-port"
+	UseNodePort      = EngressKey + "/use-node-port"
 	SSLRedirect      = EngressKey + "/ssl-redirect"
 	ForceSSLRedirect = EngressKey + "/force-ssl-redirect"
 
@@ -280,7 +280,7 @@ func init() {
 	registerParser(AuthTLSErrorPage, meta.GetString)
 	registerParser(ErrorFiles, meta.GetString)
 	registerParser(CORSEnabled, meta.GetBool)
-	registerParser(ForceServicePort, meta.GetBool)
+	registerParser(UseNodePort, meta.GetBool)
 	registerParser(EnableHSTS, meta.GetBool)
 	registerParser(HSTSPreload, meta.GetBool)
 	registerParser(HSTSIncludeSubDomains, meta.GetBool)
@@ -419,12 +419,12 @@ func (r Ingress) AllowCORSCred() bool {
 	return true // default value
 }
 
-func (r Ingress) ForceServicePort() bool {
+func (r Ingress) UseNodePort() bool {
 	if r.LBType() == LBTypeNodePort {
-		v, _ := get[ForceServicePort](r.Annotations)
+		v, _ := get[UseNodePort](r.Annotations)
 		return v.(bool)
 	}
-	return true
+	return false
 }
 
 func (r Ingress) EnableHSTS() bool {

--- a/docs/concepts/ingress-types/nodeport.md
+++ b/docs/concepts/ingress-types/nodeport.md
@@ -24,131 +24,106 @@ curl -fsSL https://raw.githubusercontent.com/appscode/voyager/6.0.0-alpha.0/hack
     | bash -s -- --provider=minikube
 ```
 
-- Now, deploy test servers using [this script](/docs/examples/ingress/types/nodeport/deploy-servers.sh) script.
+- Now, deploy and expose a test servers.
 
 ```console
-curl -fsSL https://raw.githubusercontent.com/appscode/voyager/6.0.0-alpha.0/docs/examples/ingress/types/nodeport/deploy-servers.sh | bash
+$ kubectl run test-server --image=gcr.io/google_containers/echoserver:1.8
+deployment "test-server" created
 
-deployment "nginx" created
-service "web" exposed
-deployment "echoserver" created
-service "rest" exposed
+$ kubectl expose deployment test-server --type=LoadBalancer --port=80 --target-port=8080
+service "test-server" exposed
 ```
 
-- Now, create an Ingress object running `kubectl apply -f https://raw.githubusercontent.com/appscode/voyager/6.0.0-alpha.0/docs/examples/ingress/types/nodeport/ing.yaml`. Please note the annotaiton on ingress:
+- Now, create an Ingress with `ingress.appscode.com/type: NodePort` annotation.
 
 ```yaml
+$ kubectl apply -f test-ingress.yaml
+
+apiVersion: voyager.appscode.com/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
   annotations:
     ingress.appscode.com/type: NodePort
-    ingress.appscode.com/force-service-port: "true"
+spec:
+  rules:
+  - host: voyager.appscode.test
+    http:
+      paths:
+      - path: /foo
+        backend:
+          serviceName: test-server
+          servicePort: '80'
 ```
 
 ```console
 $ kubectl get pods,svc
 NAME                                       READY     STATUS    RESTARTS   AGE
-po/echoserver-848b75d85-hshcq              1/1       Running   0          2m
-po/nginx-7c87f569d-gxftw                   1/1       Running   0          5m
-po/voyager-test-ingress-55f9b58b8f-vpfmx   1/1       Running   0          1m
+po/test-server-68ddc845cd-x7dtv            1/1       Running   0          4h
+po/voyager-test-ingress-5b758664f6-4vptr   1/1       Running   0          1m
 
-NAME                       CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
-svc/kubernetes             10.0.0.1     <none>        443/TCP        7m
-svc/rest                   10.0.0.188   <none>        80/TCP         2m
-svc/voyager-test-ingress   10.0.0.216   <nodes>       80:31656/TCP   1m
-svc/web                    10.0.0.11    <none>        80/TCP         5m
-
-$ minikube ip
-192.168.99.100
+NAME                       TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
+svc/kubernetes             ClusterIP      10.96.0.1        <none>        443/TCP        2d
+svc/test-server            LoadBalancer   10.105.13.31     <pending>     80:30390/TCP   21h
+svc/voyager-test-ingress   NodePort       10.107.182.219   <none>        80:30800/TCP   39m
 ```
 
+```
+$ minikube service --url voyager-test-ingress
+http://192.168.99.100:30800
+```
 
 ```console
-$ curl -vv 192.168.99.100:31656 -H "Host: web.example.com"
-* Rebuilt URL to: 192.168.99.100:31656/
+$ curl -v -H 'Host: voyager.appscode.test' 192.168.99.100:30800/foo
 *   Trying 192.168.99.100...
-* Connected to 192.168.99.100 (192.168.99.100) port 31656 (#0)
-> GET / HTTP/1.1
-> Host: web.example.com
+* Connected to 192.168.99.100 (192.168.99.100) port 30800 (#0)
+> GET /foo HTTP/1.1
+> Host: voyager.appscode.test
 > User-Agent: curl/7.47.0
 > Accept: */*
 >
 < HTTP/1.1 200 OK
-< Server: nginx/1.13.6
-< Date: Mon, 30 Oct 2017 11:17:43 GMT
-< Content-Type: text/html
-< Content-Length: 612
-< Last-Modified: Thu, 14 Sep 2017 16:35:09 GMT
-< ETag: "59baafbd-264"
-< Accept-Ranges: bytes
-<
-<!DOCTYPE html>
-<html>
-<head>
-<title>Welcome to nginx!</title>
-<style>
-    body {
-        width: 35em;
-        margin: 0 auto;
-        font-family: Tahoma, Verdana, Arial, sans-serif;
-    }
-</style>
-</head>
-<body>
-<h1>Welcome to nginx!</h1>
-<p>If you see this page, the nginx web server is successfully installed and
-working. Further configuration is required.</p>
-
-<p>For online documentation and support please refer to
-<a href="http://nginx.org/">nginx.org</a>.<br/>
-Commercial support is available at
-<a href="http://nginx.com/">nginx.com</a>.</p>
-
-<p><em>Thank you for using nginx.</em></p>
-</body>
-</html>
-* Connection #0 to host 192.168.99.100 left intact
-```
-
-```console
-$ curl -vv 192.168.99.100:31656 -H "Host: app.example.com"
-* Rebuilt URL to: 192.168.99.100:31656/
-*   Trying 192.168.99.100...
-* Connected to 192.168.99.100 (192.168.99.100) port 31656 (#0)
-> GET / HTTP/1.1
-> Host: app.example.com
-> User-Agent: curl/7.47.0
-> Accept: */*
->
-< HTTP/1.1 200 OK
-< Server: nginx/1.10.0
-< Date: Mon, 30 Oct 2017 11:17:51 GMT
+< Date: Wed, 14 Feb 2018 09:34:30 GMT
 < Content-Type: text/plain
 < Transfer-Encoding: chunked
+< Server: echoserver
 <
-CLIENT VALUES:
-client_address=172.17.0.7
-command=GET
-real path=/
-query=nil
-request_version=1.1
-request_uri=http://app.example.com:8080/
 
-SERVER VALUES:
-server_version=nginx: 1.10.0 - lua: 10001
 
-HEADERS RECEIVED:
-accept=*/*
-connection=close
-host=app.example.com
-user-agent=curl/7.47.0
-x-forwarded-for=172.17.0.1
-BODY:
+Hostname: test-server-68ddc845cd-x7dtv
+
+Pod Information:
+	-no pod information available-
+
+Server values:
+	server_version=nginx: 1.13.3 - lua: 10008
+
+Request Information:
+	client_address=172.17.0.6
+	method=GET
+	real path=/foo
+	query=
+	request_version=1.1
+	request_uri=http://voyager.appscode.test:8080/foo
+
+Request Headers:
+	accept=*/*
+	connection=close
+	host=voyager.appscode.test
+	user-agent=curl/7.47.0
+	x-forwarded-for=172.17.0.1
+
+Request Body:
+	-no body in request-
+
 * Connection #0 to host 192.168.99.100 left intact
 ```
 
-## externalIP
+## External IP
 If you are using NodePort type Ingress, you can specify [`externalIPs`](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) for the NodePort service used to export HAProxy pods.
 
-If you are running Voyager as Ingress controller in your `baremetal` cluster and want to assing a VIP to the HAProxy service for a highly availble Ingress setup, you should use this option.
+If you are running Voyager as Ingress controller in your `baremetal` cluster and want to assing a VIP to the HAProxy service for a highly available Ingress setup, you should use this option.
 
 Below is an example Ingress yaml that shows how to specify externalIPs:
 
@@ -160,31 +135,94 @@ metadata:
   namespace: default
   annotations:
     ingress.appscode.com/type: NodePort
-    ingress.appscode.com/force-service-port: "true"
 spec:
   externalIPs:
   - a.b.c.d
   rules:
-  - host: 'web.example.com'
+  - host: voyager.appscode.test
     http:
       paths:
-      - backend:
-          serviceName: web
-          servicePort: 80
-        path: /
-  - host: '*.example.com'
-    http:
-      paths:
-      - backend:
-          serviceName: rest
-          servicePort: 80
-        path: /
+      - path: /foo
+        backend:
+          serviceName: test-server
+          servicePort: '80'
 ```
 
-## Understanding `ingress.appscode.com/force-service-port` annotation
+## Understanding `ingress.appscode.com/use-node-port` annotation
 
-When you are using `NodePort` type Ingress, your extenral clients (example, web browser) can connect to your backend services in 2 ways:
+When you are using `NodePort` type Ingress, your external clients (example, web browser) can connect to your backend services in 2 ways:
 
- - Using the `NodePort` assigned to the HAProxy service. In this scenrios, external traffic directly hits the HAProxy NodePort service. So, HAProxy will see that incoming traffic is using Host like `domain:node-port`. To ensure that HAProxy matches against the NodePort, use the annotation `ingress.appscode.com/force-service-port: "false"` . This is also considered the the default value for this annotation. So, if you do not provide this annotation, it will be considered set to `false`. To ensure that HAProxy service ports stay fixed, define them in the Ingress YAML following: https://github.com/appscode/voyager/blob/master/docs/guides/ingress/configuration/node-port.md
+ - You may expose the NodePort service using an external hardware loadbalancer (like F5) or software loadbalancer like ALB in AWS. In these scenarios, the front loadbalancer will receive connections on service port from external clients (like web browser) and connect to the HAProxy NodePorts. So, HAProxy will see that incoming traffic is using Host like `domain:ing-port`. To ensure that HAProxy matches against the NodePort, use the annotation `ingress.appscode.com/use-node-port: "false"`. This is also considered the the default value for this annotation. So, if you do not provide this annotation, it will be considered set to `false`.
 
- - You may expose the NodePort service using an external hardware loadbalancer (like F5) or software loadbalancer like ALB in AWS. In these scnerios, the front load balancer will receive connections on service port from external clients (like web browser) and connect to the HAProxy NodePorts. So, HAProxy will see that incoming traffic is using Host like `domain:ing-port`. To ensure that HAProxy matches against the NodePort, use the annotation `ingress.appscode.com/force-service-port: "true"` .
+ - Using the `NodePort` assigned to the HAProxy service. In this scenarios, external traffic directly hits the HAProxy NodePort service. So, HAProxy will see that incoming traffic is using Host like `domain:node-port`. To ensure that HAProxy matches against the NodePort, use the annotation `ingress.appscode.com/use-node-port: "true"` .
+To ensure that HAProxy service ports stay fixed, define them in the Ingress YAML following: https://github.com/appscode/voyager/blob/master/docs/guides/ingress/configuration/node-port.md
+
+Below is an example Ingress with `ingress.appscode.com/use-node-port` annotation:
+
+```yaml
+$ kubectl apply -f test-ingress.yaml
+
+apiVersion: voyager.appscode.com/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+  annotations:
+    ingress.appscode.com/type: NodePort
+    ingress.appscode.com/use-node-port: "true"
+spec:
+  rules:
+  - host: voyager.appscode.test
+    http:
+      paths:
+      - path: /foo
+        backend:
+          serviceName: test-server
+          servicePort: '80'
+```
+
+```
+$ curl -v -H 'Host: voyager.appscode.test:30800' 192.168.99.100:30800/foo
+*   Trying 192.168.99.100...
+* Connected to 192.168.99.100 (192.168.99.100) port 30800 (#0)
+> GET /foo HTTP/1.1
+> Host: voyager.appscode.test:30800
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Date: Wed, 14 Feb 2018 09:47:43 GMT
+< Content-Type: text/plain
+< Transfer-Encoding: chunked
+< Server: echoserver
+<
+
+
+Hostname: test-server-68ddc845cd-x7dtv
+
+Pod Information:
+	-no pod information available-
+
+Server values:
+	server_version=nginx: 1.13.3 - lua: 10008
+
+Request Information:
+	client_address=172.17.0.6
+	method=GET
+	real path=/foo
+	query=
+	request_version=1.1
+	request_uri=http://voyager.appscode.test:8080/foo
+
+Request Headers:
+	accept=*/*
+	connection=close
+	host=voyager.appscode.test:30800
+	user-agent=curl/7.47.0
+	x-forwarded-for=172.17.0.1
+
+Request Body:
+	-no body in request-
+
+* Connection #0 to host 192.168.99.100 left intact
+```

--- a/docs/concepts/ingress-types/nodeport.md
+++ b/docs/concepts/ingress-types/nodeport.md
@@ -24,7 +24,7 @@ curl -fsSL https://raw.githubusercontent.com/appscode/voyager/6.0.0-alpha.0/hack
     | bash -s -- --provider=minikube
 ```
 
-- Now, deploy and expose a test servers.
+- Then, deploy and expose a test server.
 
 ```console
 $ kubectl run test-server --image=gcr.io/google_containers/echoserver:1.8
@@ -69,7 +69,7 @@ svc/test-server            LoadBalancer   10.105.13.31     <pending>     80:3039
 svc/voyager-test-ingress   NodePort       10.107.182.219   <none>        80:30800/TCP   39m
 ```
 
-```
+```console
 $ minikube service --url voyager-test-ingress
 http://192.168.99.100:30800
 ```
@@ -181,7 +181,7 @@ spec:
           servicePort: '80'
 ```
 
-```
+```console
 $ curl -v -H 'Host: voyager.appscode.test:30800' 192.168.99.100:30800/foo
 *   Trying 192.168.99.100...
 * Connected to 192.168.99.100 (192.168.99.100) port 30800 (#0)

--- a/hack/docker/voyager/templates/http-frontend.cfg
+++ b/hack/docker/voyager/templates/http-frontend.cfg
@@ -72,7 +72,7 @@ frontend {{ .FrontendName }}
 	acl is_proxy_https hdr(X-Forwarded-Proto) https
 
 	{{ range $host := .Hosts }}
-	{{ with $conditions := (host_acls $host.Host $.Port $.NodePort $.ForceMatchServicePort ) }}
+	{{ with $conditions := (host_acls $host.Host $.Port $.NodePort $.UseNodePort ) }}
 	{{ range $cond := $conditions }}
 	{{ if $cond }}acl acl_{{ $host.Host | acl_name }} {{ $cond }}{{ end }}
 	{{ end }}

--- a/pkg/haproxy/api/types.go
+++ b/pkg/haproxy/api/types.go
@@ -49,7 +49,7 @@ type SharedInfo struct {
 	HSTSIncludeSubDomains bool
 	WhitelistSourceRange  string
 	MaxConnections        int
-	ForceMatchServicePort bool
+	UseNodePort           bool
 	Limit                 *Limit
 }
 

--- a/pkg/haproxy/template/template.go
+++ b/pkg/haproxy/template/template.go
@@ -37,13 +37,13 @@ func HeaderName(v string) string {
 	return v[:index]
 }
 
-func HostACLs(host string, port int, nodePort int32, forceSvcPort bool) []string {
+func HostACLs(host string, port int, nodePort int32, useNodePort bool) []string {
 	var conditions []string
 	host = strings.TrimSpace(host)
 
-	if !forceSvcPort && nodePort > 0 {
+	if useNodePort && nodePort > 0 {
 		conditions = append(conditions, hostMatcher(fmt.Sprintf("%s:%d", host, nodePort)))
-	} else if forceSvcPort && port > 0 {
+	} else if port > 0 {
 		if port != 80 && port != 443 { // non standard http ports
 			conditions = append(conditions, hostMatcher(fmt.Sprintf("%s:%d", host, port)))
 		} else if host != "" { // http or https

--- a/pkg/haproxy/template/template.go
+++ b/pkg/haproxy/template/template.go
@@ -43,7 +43,7 @@ func HostACLs(host string, port int, nodePort int32, useNodePort bool) []string 
 
 	if useNodePort && nodePort > 0 {
 		conditions = append(conditions, hostMatcher(fmt.Sprintf("%s:%d", host, nodePort)))
-	} else if port > 0 {
+	} else if !useNodePort && port > 0 {
 		if port != 80 && port != 443 { // non standard http ports
 			conditions = append(conditions, hostMatcher(fmt.Sprintf("%s:%d", host, port)))
 		} else if host != "" { // http or https

--- a/pkg/ingress/parser.go
+++ b/pkg/ingress/parser.go
@@ -277,7 +277,7 @@ func (c *controller) generateConfig() error {
 		HSTSIncludeSubDomains: c.Ingress.HSTSIncludeSubDomains(),
 		WhitelistSourceRange:  c.Ingress.WhitelistSourceRange(),
 		MaxConnections:        c.Ingress.MaxConnections(),
-		ForceMatchServicePort: c.Ingress.ForceServicePort(),
+		UseNodePort:           c.Ingress.UseNodePort(),
 		Limit: &hpi.Limit{
 			Connection: c.Ingress.LimitConnections(),
 		},

--- a/test/e2e/ingress_nodeport.go
+++ b/test/e2e/ingress_nodeport.go
@@ -62,10 +62,10 @@ var _ = Describe("IngressNodePort", func() {
 		})
 	})
 
-	Describe("Create With Force Service Port set", func() {
+	Describe("Create With Force Node Port set", func() {
 		BeforeEach(func() {
 			ing.Annotations[api.LBType] = api.LBTypeNodePort
-			ing.Annotations[api.ForceServicePort] = "true"
+			ing.Annotations[api.UseNodePort] = "true"
 			ing.Spec.Rules[0].Host = framework.TestDomain
 			ing.Spec.Rules[0].HTTP.NodePort = intstr.FromInt(32369)
 		})

--- a/test/e2e/ingress_nodeport.go
+++ b/test/e2e/ingress_nodeport.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var _ = Describe("IngressNodePort", func() {
+var _ = FDescribe("IngressNodePort", func() {
 	var (
 		f   *framework.Invocation
 		ing *api.Ingress
@@ -53,7 +53,7 @@ var _ = Describe("IngressNodePort", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(eps)).Should(BeNumerically(">=", 1))
 
-			err = f.Ingress.DoHTTP(framework.MaxRetry, framework.TestDomain+":32368", ing, eps, "GET", "/testpath/ok", func(r *client.Response) bool {
+			err = f.Ingress.DoHTTP(framework.MaxRetry, framework.TestDomain, ing, eps, "GET", "/testpath/ok", func(r *client.Response) bool {
 				return Expect(r.Status).Should(Equal(http.StatusOK)) &&
 					Expect(r.Method).Should(Equal("GET")) &&
 					Expect(r.Path).Should(Equal("/testpath/ok"))
@@ -76,7 +76,7 @@ var _ = Describe("IngressNodePort", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(eps)).Should(BeNumerically(">=", 1))
 
-			err = f.Ingress.DoHTTP(framework.MaxRetry, framework.TestDomain, ing, eps, "GET", "/testpath/ok", func(r *client.Response) bool {
+			err = f.Ingress.DoHTTP(framework.MaxRetry, framework.TestDomain+":32369", ing, eps, "GET", "/testpath/ok", func(r *client.Response) bool {
 				return Expect(r.Status).Should(Equal(http.StatusOK)) &&
 					Expect(r.Method).Should(Equal("GET")) &&
 					Expect(r.Path).Should(Equal("/testpath/ok"))

--- a/test/e2e/ingress_nodeport.go
+++ b/test/e2e/ingress_nodeport.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var _ = FDescribe("IngressNodePort", func() {
+var _ = Describe("IngressNodePort", func() {
 	var (
 		f   *framework.Invocation
 		ing *api.Ingress


### PR DESCRIPTION
### Default

```yaml
apiVersion: voyager.appscode.com/v1beta1
kind: Ingress
metadata:
  name: test-ingress
  namespace: default
  annotations:
    ingress.appscode.com/type: NodePort
spec:
  rules:
  - host: voyager.appscode.test
    http:
      port: '8989'
      nodePort: '32666'
      paths:
      - path: /foo
        backend:
          serviceName: test-server
          servicePort: '80'
```
Generated haproxy.cfg:
```
# HAProxy configuration generated by https://github.com/appscode/voyager
# DO NOT EDIT!
global
	daemon
	stats socket /tmp/haproxy
	server-state-file global
	server-state-base /var/state/haproxy/
	# log using a syslog socket
	log /dev/log local0 info
	log /dev/log local0 notice
	tune.ssl.default-dh-param 2048
	ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
defaults
	log global
	# https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-option%20abortonclose
	# https://github.com/appscode/voyager/pull/403
	option dontlognull
	option http-server-close
	# Timeout values
	timeout client 50s
	timeout client-fin 50s
	timeout connect 50s
	timeout server 50s
	timeout tunnel 50s
	# Configure error files
	# default traffic mode is http
	# mode is overwritten in case of tcp services
	mode http
frontend http-0_0_0_0-8989
	bind *:8989 
	mode http
	option httplog
	option forwardfor
	acl is_proxy_https hdr(X-Forwarded-Proto) https
	acl acl_voyager.appscode.test hdr(host) -i voyager.appscode.test:8989
	acl acl_voyager.appscode.test:foo path_beg /foo
	use_backend test-server.default:80 if acl_voyager.appscode.test acl_voyager.appscode.test:foo
backend test-server.default:80
	server pod-test-server-68ddc845cd-x7dtv 172.17.0.4:8080
```

### With use-node-port annotation

```yaml
apiVersion: voyager.appscode.com/v1beta1
kind: Ingress
metadata:
  name: test-ingress
  namespace: default
  annotations:
    ingress.appscode.com/type: NodePort
    ingress.appscode.com/use-node-port: "true"
spec:
  rules:
  - host: voyager.appscode.test
    http:
      port: '8989'
      nodePort: '32666'
      paths:
      - path: /foo
        backend:
          serviceName: test-server
          servicePort: '80'
```
Generated haproxy.cfg:
```
# HAProxy configuration generated by https://github.com/appscode/voyager
# DO NOT EDIT!
global
	daemon
	stats socket /tmp/haproxy
	server-state-file global
	server-state-base /var/state/haproxy/
	# log using a syslog socket
	log /dev/log local0 info
	log /dev/log local0 notice
	tune.ssl.default-dh-param 2048
	ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
defaults
	log global
	# https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-option%20abortonclose
	# https://github.com/appscode/voyager/pull/403
	option dontlognull
	option http-server-close
	# Timeout values
	timeout client 50s
	timeout client-fin 50s
	timeout connect 50s
	timeout server 50s
	timeout tunnel 50s
	# Configure error files
	# default traffic mode is http
	# mode is overwritten in case of tcp services
	mode http
frontend http-0_0_0_0-8989
	bind *:8989 
	mode http
	option httplog
	option forwardfor
	acl is_proxy_https hdr(X-Forwarded-Proto) https
	acl acl_voyager.appscode.test hdr(host) -i voyager.appscode.test:32666
	acl acl_voyager.appscode.test:foo path_beg /foo
	use_backend test-server.default:80 if acl_voyager.appscode.test acl_voyager.appscode.test:foo
backend test-server.default:80
	server pod-test-server-68ddc845cd-x7dtv 172.17.0.4:8080
```
