### PR TITLE
#970 Added metallb as a cloud provider option

### DIFF
--- a/apis/voyager/v1beta1/validator.go
+++ b/apis/voyager/v1beta1/validator.go
@@ -287,7 +287,8 @@ func (r Ingress) SupportsLBType(cloudProvider string) bool {
 			cloudProvider == "azure" ||
 			cloudProvider == "acs" ||
 			cloudProvider == "openstack" ||
-			cloudProvider == "minikube"
+			cloudProvider == "minikube" ||
+			cloudProvider == "metallb"
 	case LBTypeNodePort:
 		return cloudProvider != "acs"
 	case LBTypeHostPort:

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -169,8 +169,7 @@ Voyager works great in baremetal cluster. To install, set `--provider=baremetal`
 
 ### Installing in Baremetal Cluster with MetalLB
 
-follow the instructions for installing on baremetal but specify `metallb` as provider, then follow the instructions for [MetalLB](https://metallb.universe.tf/installation/)
-once setup, the `LoadBalancer` type for ingress' is supported.
+Follow the instructions for installing on baremetal cluster but specify `metallb` as provider. Then install MetalLB following the instructions [here](https://metallb.universe.tf/installation/). Now, you can use `LoadBalancer` type ingress in baremetal clusters.
 
 ## Verify installation
 To check if Voyager operator pods have started, run the following command:

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -30,6 +30,7 @@ To install Voyager in your Kubernetes cluster, pick the appropriate cluster prov
 # provider=gke
 # provider=minikube
 # provider=openstack
+# provider=metallb
 
 $ curl -fsSL https://raw.githubusercontent.com/appscode/voyager/6.0.0/hack/deploy/voyager.sh \
     | bash -s -- --provider=$provider
@@ -166,6 +167,10 @@ Voyager can be used in minikube using `--provider=minikube`. In Minikube, a `Loa
 
 Voyager works great in baremetal cluster. To install, set `--provider=baremetal`. In baremetal cluster, `LoadBalancer` type ingress in not supported. You can use [NodePort](/docs/concepts/ingress-types/nodeport.md), [HostPort](/docs/concepts/ingress-types/hostport.md) or [Internal](/docs/concepts/ingress-types/internal.md) ingress objects.
 
+### Installing in Baremetal Cluster with MetalLB
+
+follow the instructions for installing on baremetal but specify `metallb` as provider, then follow the instructions for [MetalLB](https://metallb.universe.tf/installation/)
+once setup, the `LoadBalancer` type for ingress' is supported.
 
 ## Verify installation
 To check if Voyager operator pods have started, run the following command:


### PR DESCRIPTION
i've applied a newly built haproxy image to the crash looping deployment and changed the args to `-cloudprovider=metallb` and the pod started up successfully.
running curl against the assigned LB-IP produced a 503 and a proper log in the container

`local0.info: Apr  5 12:18:35 haproxy[30]: 10.40.0.0:63780 [05/Apr/2018:12:18:35.428] http-0_0_0_0-80 http-0_0_0_0-80/&lt;NOSRV&gt; -1/-1/-1/-1/1 503 212 - - SC-- 0/0/0/0/0 0/0 "GET / HTTP/1.1"`