### PR TITLE
Updated validator for merging empty-host with wildcard-host  

### DIFF
--- a/apis/voyager/v1beta1/diff.go
+++ b/apis/voyager/v1beta1/diff.go
@@ -255,3 +255,14 @@ func (r Ingress) UsesAuthSecret(namespace, name string) bool {
 	}
 	return false
 }
+
+// unify wildcard-host into empty-host, this will ease template rendering
+// paths under empty-host and wildcard-host will be merged
+// but TLS will be matched separately
+func (r IngressRule) GetHost() string {
+	r.Host = strings.TrimSpace(r.Host)
+	if r.Host == `` || r.Host == `*` {
+		return ``
+	}
+	return r.Host
+}

--- a/apis/voyager/v1beta1/diff.go
+++ b/apis/voyager/v1beta1/diff.go
@@ -260,9 +260,9 @@ func (r Ingress) UsesAuthSecret(namespace, name string) bool {
 // paths under empty-host and wildcard-host will be merged
 // but TLS will be matched separately
 func (r IngressRule) GetHost() string {
-	r.Host = strings.TrimSpace(r.Host)
-	if r.Host == `` || r.Host == `*` {
+	host := strings.TrimSpace(r.Host)
+	if host == `` || host == `*` {
 		return ``
 	}
-	return r.Host
+	return host
 }

--- a/apis/voyager/v1beta1/validator.go
+++ b/apis/voyager/v1beta1/validator.go
@@ -161,13 +161,13 @@ func (r Ingress) IsValid(cloudProvider string) error {
 			}
 
 			for pi, path := range rule.HTTP.Paths {
-				if _, found := a.Hosts[rule.Host]; !found {
-					a.Hosts[rule.Host] = Paths{}
+				if _, found := a.Hosts[rule.GetHost()]; !found {
+					a.Hosts[rule.GetHost()] = Paths{}
 				}
-				if ei, found := a.Hosts[rule.Host][path.Path]; found {
+				if ei, found := a.Hosts[rule.GetHost()][path.Path]; found {
 					return errors.Errorf("spec.rule[%d].http.paths[%d] is reusing path %s for addr %s, also used in spec.rule[%d].http.paths[%d]", ri, pi, path.Path, a, ei.RuleIndex, ei.PathIndex)
 				}
-				a.Hosts[rule.Host][path.Path] = indices{RuleIndex: ri, PathIndex: pi}
+				a.Hosts[rule.GetHost()][path.Path] = indices{RuleIndex: ri, PathIndex: pi}
 
 				if !checkBackendServiceName(path.Backend.ServiceName) {
 					return errors.Errorf("spec.rule[%d].http.paths[%d] has invalid serviceName for addr %s and path %s", ri, pi, a, path.Path)
@@ -206,7 +206,7 @@ func (r Ingress) IsValid(cloudProvider string) error {
 					Address:        bindAddress,
 					PodPort:        podPort,
 					FirstRuleIndex: ri,
-					Hosts:          map[string]Paths{rule.Host: {}},
+					Hosts:          map[string]Paths{rule.GetHost(): {}},
 				}
 				addrs[addrKey] = a
 			}

--- a/apis/voyager/v1beta1/validator_test.go
+++ b/apis/voyager/v1beta1/validator_test.go
@@ -663,4 +663,92 @@ var dataTables = map[*Ingress]bool{
 			},
 		},
 	}: true,
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "Merging empty-host with wildcard-host"},
+		Spec: IngressSpec{
+			Rules: []IngressRule{
+				{
+					IngressRuleValue: IngressRuleValue{
+						HTTP: &HTTPIngressRuleValue{
+							Port: intstr.FromInt(80),
+							Paths: []HTTPIngressPath{
+								{
+									Path: "/foo",
+									Backend: HTTPIngressBackend{
+										IngressBackend: IngressBackend{
+											ServiceName: "foo",
+											ServicePort: intstr.FromInt(3444),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "*",
+					IngressRuleValue: IngressRuleValue{
+						HTTP: &HTTPIngressRuleValue{
+							Port: intstr.FromInt(80),
+							Paths: []HTTPIngressPath{
+								{
+									Path: "/not-foo",
+									Backend: HTTPIngressBackend{
+										IngressBackend: IngressBackend{
+											ServiceName: "foo",
+											ServicePort: intstr.FromInt(3444),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}: true, // merging "*" host with empty-host
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "Conflict merging empty-host with wildcard-host"},
+		Spec: IngressSpec{
+			Rules: []IngressRule{
+				{
+					IngressRuleValue: IngressRuleValue{
+						HTTP: &HTTPIngressRuleValue{
+							Port: intstr.FromInt(80),
+							Paths: []HTTPIngressPath{
+								{
+									Path: "/foo",
+									Backend: HTTPIngressBackend{
+										IngressBackend: IngressBackend{
+											ServiceName: "foo",
+											ServicePort: intstr.FromInt(3444),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "*",
+					IngressRuleValue: IngressRuleValue{
+						HTTP: &HTTPIngressRuleValue{
+							Port: intstr.FromInt(80),
+							Paths: []HTTPIngressPath{
+								{
+									Path: "/foo",
+									Backend: HTTPIngressBackend{
+										IngressBackend: IngressBackend{
+											ServiceName: "foo",
+											ServicePort: intstr.FromInt(3444),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}: false, // conflicting paths while merging "*" host with empty-host
 }

--- a/apis/voyager/v1beta1/validator_test.go
+++ b/apis/voyager/v1beta1/validator_test.go
@@ -751,4 +751,56 @@ var dataTables = map[*Ingress]bool{
 			},
 		},
 	}: false, // conflicting paths while merging "*" host with empty-host
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "Merging empty-host with wildcard-host"},
+		Spec: IngressSpec{
+			TLS: []IngressTLS{
+				{
+					SecretName: "voyager-cert",
+					Hosts: []string{
+						"*",
+					},
+				},
+			},
+			Rules: []IngressRule{
+				{
+					IngressRuleValue: IngressRuleValue{
+						HTTP: &HTTPIngressRuleValue{
+							Port: intstr.FromInt(80),
+							Paths: []HTTPIngressPath{
+								{
+									Path: "/foo",
+									Backend: HTTPIngressBackend{
+										IngressBackend: IngressBackend{
+											ServiceName: "foo",
+											ServicePort: intstr.FromInt(3444),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "*",
+					IngressRuleValue: IngressRuleValue{
+						HTTP: &HTTPIngressRuleValue{
+							Port: intstr.FromInt(80),
+							Paths: []HTTPIngressPath{
+								{
+									Path: "/not-foo",
+									Backend: HTTPIngressBackend{
+										IngressBackend: IngressBackend{
+											ServiceName: "foo",
+											ServicePort: intstr.FromInt(3444),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}: false, // conflicting TLS merging "*" host with empty-host
 }


### PR DESCRIPTION
- GetHost() is moved to API and used in validator to check path conflicts
- In parser.go, GetHost() is done only when extracting data from rule.Host, in other cases we don't need it, since they are populated from rule.Host
- If TLS is defined for `*` host and we try to merge empty-host with `*` host, it will cause conflicting TLS error, is it OK ? 