### PR TITLE
Don't exit if migration fails.

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -172,7 +172,7 @@ func (w *Operator) Run(stopCh <-chan struct{}) {
 	// https://github.com/appscode/voyager/pull/506
 	err = w.MigrateCertificates()
 	if err != nil {
-		log.Fatalln("Failed certificate migrations:", err)
+		log.Errorln("Failed certificate migrations:", err)
 	}
 	// https://github.com/appscode/voyager/issues/229
 	w.PurgeOffshootsWithDeprecatedLabels()


### PR DESCRIPTION
This happens when operator pod restarts. The webhook server is not ready yet.