### PR TITLE
Add metallb to providers that can have LoadBalancerIP set.

### DIFF
--- a/pkg/ingress/loadbalancer.go
+++ b/pkg/ingress/loadbalancer.go
@@ -335,7 +335,7 @@ func (c *loadBalancerController) ensureService() (*core.Service, kutil.VerbType,
 
 		// LoadBalancerIP
 		switch c.cfg.CloudProvider {
-		case "gce", "gke", "azure", "acs", "openstack":
+		case "gce", "gke", "azure", "acs", "openstack", "metallb":
 			if ip := c.Ingress.LoadBalancerIP(); ip != nil {
 				obj.Spec.LoadBalancerIP = ip.String()
 			}


### PR DESCRIPTION
This fixes #1105 by adding metallb to the list of cloud providers that support having the LoadBalancerIP set.