### PR TITLE
Fix documentation about external-dns service

### DIFF
--- a/docs/guides/ingress/dns/external-dns.md
+++ b/docs/guides/ingress/dns/external-dns.md
@@ -49,7 +49,7 @@ spec:
 
 ## HostPort Ingress
 
-[HostPort](/docs/concepts/ingress-types/hostport.md) type Ingress is supported by external-dns, since version [v0.5.0-alpha.1](https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.0-alpha.1). Here, apply `"external-dns.alpha.kubernetes.io/hostname"` annotation on the HAProxy **services**.
+[HostPort](/docs/concepts/ingress-types/hostport.md) type Ingress is [supported by external-dns](https://github.com/kubernetes-incubator/external-dns/blob/v0.5.2/docs/tutorials/hostport.md). Here, apply `"external-dns.alpha.kubernetes.io/hostname"` annotation on the HAProxy **services**.
 
 ```yaml
 apiVersion: voyager.appscode.com/v1beta1

--- a/docs/guides/ingress/dns/external-dns.md
+++ b/docs/guides/ingress/dns/external-dns.md
@@ -49,7 +49,7 @@ spec:
 
 ## HostPort Ingress
 
-[HostPort](/docs/concepts/ingress-types/hostport.md) type Ingress is supported by external-dns, since version [v0.5.0-alpha.1](https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.0-alpha.1). Here, apply `"external-dns.alpha.kubernetes.io/hostname"` annotation on the HAProxy **pods**.
+[HostPort](/docs/concepts/ingress-types/hostport.md) type Ingress is supported by external-dns, since version [v0.5.0-alpha.1](https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.0-alpha.1). Here, apply `"external-dns.alpha.kubernetes.io/hostname"` annotation on the HAProxy **services**.
 
 ```yaml
 apiVersion: voyager.appscode.com/v1beta1
@@ -59,7 +59,7 @@ metadata:
   namespace: vdimov-dev
   annotations:
      ingress.appscode.com/type: HostPort
-     ingress.appscode.com/annotations-pod: |
+     ingress.appscode.com/annotations-service: |
          {
            "external-dns.alpha.kubernetes.io/hostname" : "voyager.example.com,voyager-1.example.com,voyager-2.example.com"
          }


### PR DESCRIPTION
I'm using HostPort type ingress.
For me annotation on service works, not on pod.

Using external-dns version 0.5.2