### PR TITLE
Do not create namespace from yaml, it gets created with kubectl manually

### DIFF
--- a/docs/examples/monitoring/coreos-operator/demo-0.yaml
+++ b/docs/examples/monitoring/coreos-operator/demo-0.yaml
@@ -1,11 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: demo
-spec:
-  finalizers:
-  - kubernetes
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/examples/monitoring/coreos-operator/rbac/demo-0.yaml
+++ b/docs/examples/monitoring/coreos-operator/rbac/demo-0.yaml
@@ -1,11 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: demo
-spec:
-  finalizers:
-  - kubernetes
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/guides/ingress/monitoring/using-coreos-prometheus-operator.md
+++ b/docs/guides/ingress/monitoring/using-coreos-prometheus-operator.md
@@ -46,7 +46,6 @@ If RBAC *is* enabled, Run the following command to prepare your cluster for this
 
 ```console
 $ kubectl create -f https://raw.githubusercontent.com/appscode/voyager/7.1.0/docs/examples/monitoring/coreos-operator/rbac/demo-0.yaml
-namespace "demo" created
 clusterrole "prometheus-operator" created
 serviceaccount "prometheus-operator" created
 clusterrolebinding "prometheus-operator" created
@@ -98,7 +97,6 @@ If RBAC *is not* enabled, Run the following command to prepare your cluster for 
 
 ```console
 $ kubectl create -f https://raw.githubusercontent.com/appscode/voyager/7.1.0/docs/examples/monitoring/coreos-operator/demo-0.yaml
-namespace "demo" created
 deployment "prometheus-operator" created
 
 $ kubectl get pods -n demo --watch


### PR DESCRIPTION
If you follow docs step by step, namespace gets created manually in the beginning.
Moreover it will be easier to `kubectl delete -f https://raw.githubusercontent.com/appscode/voyager/7.0.0/docs/examples/monitoring/coreos-operator/...` later without complete namespace removal 