### PR TITLE
Add nodeSelector for the operator

### DIFF
--- a/hack/deploy/operator.yaml
+++ b/hack/deploy/operator.yaml
@@ -57,6 +57,7 @@ spec:
             cpu: "100m"
       nodeSelector:
         beta.kubernetes.io/os: linux
+        beta.kubernetes.io/arch: amd64
       volumes:
       - hostPath:
           path: /etc/kubernetes

--- a/hack/deploy/operator.yaml
+++ b/hack/deploy/operator.yaml
@@ -55,6 +55,8 @@ spec:
         resources:
           requests:
             cpu: "100m"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       volumes:
       - hostPath:
           path: /etc/kubernetes


### PR DESCRIPTION
In a mixed cluster comprised of both Windows and Linux containers, this nodeSelector is required to ensure voyager is deployed to the linux container.