### PR TITLE
Remove description on root schema

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2287,7 +2287,6 @@
       }
     },
     "com.github.appscode.voyager.apis.voyager.v1beta1.Ingress": {
-      "description": "Custom Ingress type for Voyager.",
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",

--- a/apis/voyager/v1beta1/crds.yaml
+++ b/apis/voyager/v1beta1/crds.yaml
@@ -17,7 +17,6 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: Custom Ingress type for Voyager.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/apis/voyager/v1beta1/ingress.go
+++ b/apis/voyager/v1beta1/ingress.go
@@ -16,7 +16,6 @@ const (
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Custom Ingress type for Voyager.
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/apis/voyager/v1beta1/openapi_generated.go
+++ b/apis/voyager/v1beta1/openapi_generated.go
@@ -783,7 +783,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/appscode/voyager/apis/voyager/v1beta1.Ingress": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Custom Ingress type for Voyager.",
 					Properties: map[string]spec.Schema{
 						"kind": {
 							SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
In the latest version of kubernetes server having description at the
root of the schema is invalid and blocks creation of the schema.

The operator logs show the following error:

```
I0630 01:45:19.699218       1 logs.go:19] CustomResourceDefinition.apiextensions.k8s.io "ingresses.voyager.appscode.com" is invalid: spec.validation.openAPIV3Schema: Invalid value: apiextensions.JSONSchemaProps{ID:"", Schema:"", Ref:(*string)(nil), Description:"Custom Ingress type for Voyager.", Type:"", Format:"", Title:"", Default:(*apiextensions.JSON)(nil), Maximum:(*float64)(nil), ExclusiveMaximum:false, Minimum:(*float64)(nil), ExclusiveMinimum:false, MaxLength:(*int64)(nil), MinLength:(*int64)(nil), Pattern:"", MaxItems:(*int64)(nil), MinItems:(*int64)(nil), UniqueItems:false, MultipleOf:(*float64)(nil), Enum:[]apiextensions.JSON(nil), MaxProperties:(*int64)(nil)

...

Example:(*apiextensions.JSON)(nil)}: if subresources for custom resources are enabled, only properties can be used at the root of the schema
```

Once this change is in place the Ingress can be successfully created.

For context:

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.2", GitCommit:"81753b10df112992bf51bbc2c2f85208aad78335", GitTreeState:"clean", BuildDate:"2018-05-12T04:12:47Z", GoVersion:"go1.9.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.5", GitCommit:"32ac1c9073b132b8ba18aa830f46b77dcceb0723", GitTreeState:"clean", BuildDate:"2018-06-21T11:34:22Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
```