### PR TITLE
Sort pod annotations to avoid template changes

### DIFF
--- a/pkg/ingress/hostport.go
+++ b/pkg/ingress/hostport.go
@@ -352,6 +352,7 @@ func (c *hostPortController) ensureService() (*core.Service, kutil.VerbType, err
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// ExternalIPs
@@ -418,6 +419,7 @@ func (c *hostPortController) ensurePods() (kutil.VerbType, error) {
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Spec.Template.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// pod spec

--- a/pkg/ingress/internal.go
+++ b/pkg/ingress/internal.go
@@ -273,6 +273,7 @@ func (c *internalController) ensureService() (*core.Service, kutil.VerbType, err
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// ExternalIPs
@@ -340,6 +341,7 @@ func (c *internalController) ensurePods() (kutil.VerbType, error) {
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Spec.Template.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// pod spec

--- a/pkg/ingress/loadbalancer.go
+++ b/pkg/ingress/loadbalancer.go
@@ -280,6 +280,7 @@ func (c *loadBalancerController) ensureService() (*core.Service, kutil.VerbType,
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// Remove old annotations from 3.2.x release.
@@ -391,6 +392,7 @@ func (c *loadBalancerController) ensurePods() (kutil.VerbType, error) {
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Spec.Template.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// pod spec

--- a/pkg/ingress/nodeport.go
+++ b/pkg/ingress/nodeport.go
@@ -377,6 +377,7 @@ func (c *nodePortController) ensureService() (*core.Service, kutil.VerbType, err
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// LoadBalancerSourceRanges
@@ -455,6 +456,7 @@ func (c *nodePortController) ensurePods() (kutil.VerbType, error) {
 				newKeys = append(newKeys, k)
 			}
 		}
+		sort.Strings(newKeys)
 		obj.Spec.Template.Annotations[api.LastAppliedAnnotationKeys] = strings.Join(newKeys, ",")
 
 		// pod spec


### PR DESCRIPTION
Fixes #1251

Sort pod annotations to make `ingress.appscode.com/last-applied-annotation-keys` stable and avoid triggering rolling update

