### PR TITLE
Support readinessProbe and livenessProbe

### DIFF
--- a/api/crds/ingress.yaml
+++ b/api/crds/ingress.yaml
@@ -1007,6 +1007,103 @@ spec:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
               type: array
+            livenessProbe:
+              description: Probe describes a health check to be performed against
+                a container to determine whether it is alive or ready to receive traffic.
+              properties:
+                exec:
+                  description: ExecAction describes a "run in container" action.
+                  properties:
+                    command:
+                      description: Command is the command line to execute inside the
+                        container, the working directory for the command  is root
+                        ('/') in the container's filesystem. The command is simply
+                        exec'd, it is not run inside a shell, so traditional shell
+                        instructions ('|', etc) won't work. To use a shell, you need
+                        to explicitly call out to that shell. Exit status of 0 is
+                        treated as live/healthy and non-zero is unhealthy.
+                      items:
+                        type: string
+                      type: array
+                failureThreshold:
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                  format: int32
+                  type: integer
+                httpGet:
+                  description: HTTPGetAction describes an action based on HTTP Get
+                    requests.
+                  properties:
+                    host:
+                      description: Host name to connect to, defaults to the pod IP.
+                        You probably want to set "Host" in httpHeaders instead.
+                      type: string
+                    httpHeaders:
+                      description: Custom headers to set in the request. HTTP allows
+                        repeated headers.
+                      items:
+                        description: HTTPHeader describes a custom header to be used
+                          in HTTP probes
+                        properties:
+                          name:
+                            description: The header field name
+                            type: string
+                          value:
+                            description: The header field value
+                            type: string
+                        required:
+                        - name
+                        - value
+                      type: array
+                    path:
+                      description: Path to access on the HTTP server.
+                      type: string
+                    port:
+                      oneOf:
+                      - type: string
+                      - type: integer
+                    scheme:
+                      description: Scheme to use for connecting to the host. Defaults
+                        to HTTP.
+                      type: string
+                  required:
+                  - port
+                initialDelaySeconds:
+                  description: 'Number of seconds after the container has started
+                    before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                tcpSocket:
+                  description: TCPSocketAction describes an action based on opening
+                    a socket
+                  properties:
+                    host:
+                      description: 'Optional: Host name to connect to, defaults to
+                        the pod IP.'
+                      type: string
+                    port:
+                      oneOf:
+                      - type: string
+                      - type: integer
+                  required:
+                  - port
+                timeoutSeconds:
+                  description: 'Number of seconds after which the probe times out.
+                    Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  format: int32
+                  type: integer
             loadBalancerSourceRanges:
               description: 'Optional: If specified and supported by the platform,
                 this will restrict traffic through the cloud-provider load-balancer
@@ -1036,6 +1133,103 @@ spec:
                 with that name. If not specified, the pod priority will be default
                 or zero if there is no default.
               type: string
+            readinessProbe:
+              description: Probe describes a health check to be performed against
+                a container to determine whether it is alive or ready to receive traffic.
+              properties:
+                exec:
+                  description: ExecAction describes a "run in container" action.
+                  properties:
+                    command:
+                      description: Command is the command line to execute inside the
+                        container, the working directory for the command  is root
+                        ('/') in the container's filesystem. The command is simply
+                        exec'd, it is not run inside a shell, so traditional shell
+                        instructions ('|', etc) won't work. To use a shell, you need
+                        to explicitly call out to that shell. Exit status of 0 is
+                        treated as live/healthy and non-zero is unhealthy.
+                      items:
+                        type: string
+                      type: array
+                failureThreshold:
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                  format: int32
+                  type: integer
+                httpGet:
+                  description: HTTPGetAction describes an action based on HTTP Get
+                    requests.
+                  properties:
+                    host:
+                      description: Host name to connect to, defaults to the pod IP.
+                        You probably want to set "Host" in httpHeaders instead.
+                      type: string
+                    httpHeaders:
+                      description: Custom headers to set in the request. HTTP allows
+                        repeated headers.
+                      items:
+                        description: HTTPHeader describes a custom header to be used
+                          in HTTP probes
+                        properties:
+                          name:
+                            description: The header field name
+                            type: string
+                          value:
+                            description: The header field value
+                            type: string
+                        required:
+                        - name
+                        - value
+                      type: array
+                    path:
+                      description: Path to access on the HTTP server.
+                      type: string
+                    port:
+                      oneOf:
+                      - type: string
+                      - type: integer
+                    scheme:
+                      description: Scheme to use for connecting to the host. Defaults
+                        to HTTP.
+                      type: string
+                  required:
+                  - port
+                initialDelaySeconds:
+                  description: 'Number of seconds after the container has started
+                    before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                tcpSocket:
+                  description: TCPSocketAction describes an action based on opening
+                    a socket
+                  properties:
+                    host:
+                      description: 'Optional: Host name to connect to, defaults to
+                        the pod IP.'
+                      type: string
+                    port:
+                      oneOf:
+                      - type: string
+                      - type: integer
+                  required:
+                  - port
+                timeoutSeconds:
+                  description: 'Number of seconds after which the probe times out.
+                    Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  format: int32
+                  type: integer
             resources:
               description: ResourceRequirements describes the compute resource requirements.
               properties:
@@ -1332,6 +1526,11 @@ spec:
                     - name
                     - value
                   type: array
+            terminationGracePeriodSeconds:
+              description: Set this value longer than the expected cleanup time for
+                your process. Defaults to 30 seconds.
+              format: int64
+              type: integer
             tls:
               description: TLS is the TLS configuration. Currently the Ingress only
                 supports a single TLS port, 443, and assumes TLS termination. If multiple

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2382,6 +2382,10 @@
             "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           }
         },
+        "livenessProbe": {
+          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+        },
         "loadBalancerSourceRanges": {
           "description": "Optional: If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/",
           "type": "array",
@@ -2405,6 +2409,10 @@
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
         },
+        "readinessProbe": {
+          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+        },
         "resources": {
           "description": "Compute Resources required by the sidecar container.",
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
@@ -2423,6 +2431,11 @@
         "securityContext": {
           "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
           "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+          "type": "integer",
+          "format": "int64"
         },
         "tls": {
           "description": "TLS is the TLS configuration. Currently the Ingress only supports a single TLS port, 443, and assumes TLS termination. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension.",
@@ -2586,6 +2599,66 @@
         "podAntiAffinity": {
           "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
           "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity"
+        }
+      }
+    },
+    "io.k8s.api.core.v1.ExecAction": {
+      "description": "ExecAction describes a \"run in container\" action.",
+      "properties": {
+        "command": {
+          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "io.k8s.api.core.v1.HTTPGetAction": {
+      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+      "required": [
+        "port"
+      ],
+      "properties": {
+        "host": {
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+          "type": "string"
+        },
+        "httpHeaders": {
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
+          }
+        },
+        "path": {
+          "description": "Path to access on the HTTP server.",
+          "type": "string"
+        },
+        "port": {
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+        },
+        "scheme": {
+          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+          "type": "string"
+        }
+      }
+    },
+    "io.k8s.api.core.v1.HTTPHeader": {
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "description": "The header field name",
+          "type": "string"
+        },
+        "value": {
+          "description": "The header field value",
+          "type": "string"
         }
       }
     },
@@ -2819,6 +2892,48 @@
         }
       }
     },
+    "io.k8s.api.core.v1.Probe": {
+      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+      "properties": {
+        "exec": {
+          "description": "One and only one of the following should be specified. Exec specifies the action to take.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
+        },
+        "failureThreshold": {
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "httpGet": {
+          "description": "HTTPGet specifies the http request to perform.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+        },
+        "initialDelaySeconds": {
+          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "type": "integer",
+          "format": "int32"
+        },
+        "periodSeconds": {
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "successThreshold": {
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "tcpSocket": {
+          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+        },
+        "timeoutSeconds": {
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "io.k8s.api.core.v1.ResourceRequirements": {
       "description": "ResourceRequirements describes the compute resource requirements.",
       "properties": {
@@ -2873,6 +2988,22 @@
         "value": {
           "description": "Value of a property to set",
           "type": "string"
+        }
+      }
+    },
+    "io.k8s.api.core.v1.TCPSocketAction": {
+      "description": "TCPSocketAction describes an action based on opening a socket",
+      "required": [
+        "port"
+      ],
+      "properties": {
+        "host": {
+          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+          "type": "string"
+        },
+        "port": {
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
         }
       }
     },

--- a/apis/voyager/v1beta1/ingress.go
+++ b/apis/voyager/v1beta1/ingress.go
@@ -138,6 +138,23 @@ type IngressSpec struct {
 	// that are not part of the Kubernetes system.
 	// +optional
 	ExternalIPs []string `json:"externalIPs,omitempty"`
+
+	// Periodic probe of container liveness.
+	// Container will be restarted if the probe fails.
+	// Cannot be updated.
+	// +optional
+	LivenessProbe *core.Probe `json:"livenessProbe,omitempty"`
+
+	// Periodic probe of container service readiness.
+	// Container will be removed from service endpoints if the probe fails.
+	// Cannot be updated.
+	// +optional
+	ReadinessProbe *core.Probe `json:"readinessProbe,omitempty"`
+
+	// Set this value longer than the expected cleanup time for your process.
+	// Defaults to 30 seconds.
+	// +optional
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }
 
 // IngressTLS describes the transport layer security associated with an Ingress.

--- a/apis/voyager/v1beta1/openapi_generated.go
+++ b/apis/voyager/v1beta1/openapi_generated.go
@@ -1468,11 +1468,30 @@ func schema_voyager_apis_voyager_v1beta1_IngressSpec(ref common.ReferenceCallbac
 							},
 						},
 					},
+					"livenessProbe": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated.",
+							Ref:         ref("k8s.io/api/core/v1.Probe"),
+						},
+					},
+					"readinessProbe": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated.",
+							Ref:         ref("k8s.io/api/core/v1.Probe"),
+						},
+					},
+					"terminationGracePeriodSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/appscode/voyager/apis/voyager/v1beta1.FrontendRule", "github.com/appscode/voyager/apis/voyager/v1beta1.HTTPIngressBackend", "github.com/appscode/voyager/apis/voyager/v1beta1.IngressRule", "github.com/appscode/voyager/apis/voyager/v1beta1.IngressTLS", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
+			"github.com/appscode/voyager/apis/voyager/v1beta1.FrontendRule", "github.com/appscode/voyager/apis/voyager/v1beta1.HTTPIngressBackend", "github.com/appscode/voyager/apis/voyager/v1beta1.IngressRule", "github.com/appscode/voyager/apis/voyager/v1beta1.IngressTLS", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 

--- a/apis/voyager/v1beta1/zz_generated.deepcopy.go
+++ b/apis/voyager/v1beta1/zz_generated.deepcopy.go
@@ -751,6 +751,33 @@ func (in *IngressSpec) DeepCopyInto(out *IngressSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.LivenessProbe != nil {
+		in, out := &in.LivenessProbe, &out.LivenessProbe
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Probe)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.ReadinessProbe != nil {
+		in, out := &in.ReadinessProbe, &out.ReadinessProbe
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Probe)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int64)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/ingress/hostport.go
+++ b/pkg/ingress/hostport.go
@@ -434,6 +434,7 @@ func (c *hostPortController) ensurePods() (kutil.VerbType, error) {
 		obj.Spec.Template.Spec.SecurityContext = c.Ingress.Spec.SecurityContext
 		obj.Spec.Template.Spec.HostNetwork = true
 		obj.Spec.Template.Spec.DNSPolicy = core.DNSClusterFirstWithHostNet
+		obj.Spec.Template.Spec.TerminationGracePeriodSeconds = c.Ingress.Spec.TerminationGracePeriodSeconds
 		if c.cfg.EnableRBAC {
 			obj.Spec.Template.Spec.ServiceAccountName = c.Ingress.OffshootName()
 		}
@@ -482,8 +483,10 @@ func (c *hostPortController) ensurePods() (kutil.VerbType, error) {
 					Value: config.AnalyticsClientID,
 				},
 			}),
-			Ports:     []core.ContainerPort{},
-			Resources: c.Ingress.Spec.Resources,
+			Ports:          []core.ContainerPort{},
+			Resources:      c.Ingress.Spec.Resources,
+			LivenessProbe:  c.Ingress.Spec.LivenessProbe,
+			ReadinessProbe: c.Ingress.Spec.ReadinessProbe,
 			VolumeMounts: []core.VolumeMount{
 				{
 					Name:      TLSCertificateVolumeName,

--- a/pkg/ingress/internal.go
+++ b/pkg/ingress/internal.go
@@ -354,6 +354,7 @@ func (c *internalController) ensurePods() (kutil.VerbType, error) {
 		obj.Spec.Template.Spec.PriorityClassName = c.Ingress.Spec.PriorityClassName
 		obj.Spec.Template.Spec.Priority = c.Ingress.Spec.Priority
 		obj.Spec.Template.Spec.SecurityContext = c.Ingress.Spec.SecurityContext
+		obj.Spec.Template.Spec.TerminationGracePeriodSeconds = c.Ingress.Spec.TerminationGracePeriodSeconds
 		if c.cfg.EnableRBAC {
 			obj.Spec.Template.Spec.ServiceAccountName = c.Ingress.OffshootName()
 		}
@@ -402,8 +403,10 @@ func (c *internalController) ensurePods() (kutil.VerbType, error) {
 					Value: config.AnalyticsClientID,
 				},
 			}),
-			Ports:     []core.ContainerPort{},
-			Resources: c.Ingress.Spec.Resources,
+			Ports:          []core.ContainerPort{},
+			Resources:      c.Ingress.Spec.Resources,
+			LivenessProbe:  c.Ingress.Spec.LivenessProbe,
+			ReadinessProbe: c.Ingress.Spec.ReadinessProbe,
 			VolumeMounts: []core.VolumeMount{
 				{
 					Name:      TLSCertificateVolumeName,

--- a/pkg/ingress/loadbalancer.go
+++ b/pkg/ingress/loadbalancer.go
@@ -405,6 +405,7 @@ func (c *loadBalancerController) ensurePods() (kutil.VerbType, error) {
 		obj.Spec.Template.Spec.PriorityClassName = c.Ingress.Spec.PriorityClassName
 		obj.Spec.Template.Spec.Priority = c.Ingress.Spec.Priority
 		obj.Spec.Template.Spec.SecurityContext = c.Ingress.Spec.SecurityContext
+		obj.Spec.Template.Spec.TerminationGracePeriodSeconds = c.Ingress.Spec.TerminationGracePeriodSeconds
 		if c.cfg.EnableRBAC {
 			obj.Spec.Template.Spec.ServiceAccountName = c.Ingress.OffshootName()
 		}
@@ -453,8 +454,10 @@ func (c *loadBalancerController) ensurePods() (kutil.VerbType, error) {
 					Value: config.AnalyticsClientID,
 				},
 			}),
-			Ports:     []core.ContainerPort{},
-			Resources: c.Ingress.Spec.Resources,
+			Ports:          []core.ContainerPort{},
+			Resources:      c.Ingress.Spec.Resources,
+			LivenessProbe:  c.Ingress.Spec.LivenessProbe,
+			ReadinessProbe: c.Ingress.Spec.ReadinessProbe,
 			VolumeMounts: []core.VolumeMount{
 				{
 					Name:      TLSCertificateVolumeName,

--- a/pkg/ingress/nodeport.go
+++ b/pkg/ingress/nodeport.go
@@ -469,6 +469,7 @@ func (c *nodePortController) ensurePods() (kutil.VerbType, error) {
 		obj.Spec.Template.Spec.PriorityClassName = c.Ingress.Spec.PriorityClassName
 		obj.Spec.Template.Spec.Priority = c.Ingress.Spec.Priority
 		obj.Spec.Template.Spec.SecurityContext = c.Ingress.Spec.SecurityContext
+		obj.Spec.Template.Spec.TerminationGracePeriodSeconds = c.Ingress.Spec.TerminationGracePeriodSeconds
 		if c.cfg.EnableRBAC {
 			obj.Spec.Template.Spec.ServiceAccountName = c.Ingress.OffshootName()
 		}
@@ -517,8 +518,10 @@ func (c *nodePortController) ensurePods() (kutil.VerbType, error) {
 					Value: config.AnalyticsClientID,
 				},
 			}),
-			Ports:     []core.ContainerPort{},
-			Resources: c.Ingress.Spec.Resources,
+			Ports:          []core.ContainerPort{},
+			Resources:      c.Ingress.Spec.Resources,
+			LivenessProbe:  c.Ingress.Spec.LivenessProbe,
+			ReadinessProbe: c.Ingress.Spec.ReadinessProbe,
 			VolumeMounts: []core.VolumeMount{
 				{
 					Name:      TLSCertificateVolumeName,


### PR DESCRIPTION
Allow users to specify probes for generated deployments
(also, terminationGracePeriodSeconds). 

Tested using HAProxy's builtin `monitor-uri`.

Fixes #1262 