### PR TITLE
readme: overview: certificates.voyager.appscode.com

### DIFF
--- a/docs/guides/ingress/tls/overview.md
+++ b/docs/guides/ingress/tls/overview.md
@@ -13,8 +13,8 @@ section_menu_id: guides
 > New to Voyager? Please start [here](/docs/concepts/overview.md).
 
 # TLS
-You can secure an Ingress by specifying a secret containing TLS pem or by referring a `certificate.voyager.appscode.com` resource.
-`certificate.voyager.appscode.com` can manage an certificate resource and use that certificate to encrypt communication.
+You can secure an Ingress by specifying a secret containing TLS pem or by referring a `certificates.voyager.appscode.com` resource.
+`certificates.voyager.appscode.com` can manage an certificate resource and use that certificate to encrypt communication.
 
 This tutorial will show you how to secure an Ingress using TLS/SSL certificates.
 


### PR DESCRIPTION
Should be certificates.voyager.appscode.com, I think.

```bash
kubectl get crd -l app=voyager
NAME                                CREATED AT
certificates.voyager.appscode.com   2019-01-15T20:24:31Z
ingresses.voyager.appscode.com      2019-01-15T20:24:31Z
```