### PR TITLE
remove single quotes from servicePort

### DIFF
--- a/docs/guides/ingress/http/single-service.md
+++ b/docs/guides/ingress/http/single-service.md
@@ -26,7 +26,7 @@ metadata:
 spec:
   backend:
     serviceName: test-service
-    servicePort: '80'
+    servicePort: 80
 ```
 
 This will create a load balancer forwarding all traffic to `test-service` service, unconditionally. The
@@ -45,20 +45,20 @@ metadata:
 spec:
   backend:
     serviceName: default-service
-    servicePort: '80'
+    servicePort: 80
   rules:
   - host: appscode.example.com
     http:
       paths:
       - backend:
           serviceName: test-service
-          servicePort: '80'
+          servicePort: 80
   - host: default.example.com
     http:
       paths:
       - backend:
           serviceName: default-service
-          servicePort: '80'
+          servicePort: 80
 ```
 **Default Backend**: An Ingress with no rules, like the one shown in the previous section, sends all
 traffic to a single default backend. You can use the same technique to tell a loadbalancer


### PR DESCRIPTION
The Ingress "ingress-test" is invalid: spec.backend.servicePort: Invalid value: "80": must contain at least one letter or number (a-z, 0-9)