### PR TITLE
Change timeout connect to 5s

### DIFF
--- a/apis/voyager/v1beta1/annotations.go
+++ b/apis/voyager/v1beta1/annotations.go
@@ -103,7 +103,7 @@ const (
 	//
 	// If the annotation is not set default values used to config defaults section will be:
 	//
-	// timeout  connect         50s
+	// timeout  connect         5s
 	// timeout  client          50s
 	// timeout  client-fin      50s
 	// timeout  server          50s
@@ -662,7 +662,7 @@ var timeoutKeys = []string{
 
 var timeoutDefaults = map[string]string{
 	// Maximum time to wait for a connection attempt to a server to succeed.
-	"connect": "50s",
+	"connect": "5s",
 
 	// Maximum inactivity time on the client side.
 	// Applies when the client is expected to acknowledge or send data.

--- a/docs/examples/ingress/types/hostport/haproxy.cfg
+++ b/docs/examples/ingress/types/hostport/haproxy.cfg
@@ -19,7 +19,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/examples/ingress/types/internal/haproxy.cfg
+++ b/docs/examples/ingress/types/internal/haproxy.cfg
@@ -19,7 +19,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/examples/ingress/types/loadbalancer/haproxy.cfg
+++ b/docs/examples/ingress/types/loadbalancer/haproxy.cfg
@@ -19,7 +19,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/examples/ingress/types/nodeport/haproxy.cfg
+++ b/docs/examples/ingress/types/nodeport/haproxy.cfg
@@ -19,7 +19,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/accept-proxy.md
+++ b/docs/guides/ingress/configuration/accept-proxy.md
@@ -88,7 +88,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/annotations.md
+++ b/docs/guides/ingress/configuration/annotations.md
@@ -34,7 +34,7 @@ Below is the full list of supported annotations:
 | [ingress.appscode.com/cors-allow-methods](/docs/guides/ingress/http/cors.md) | string | `GET,PUT,POST,DELETE,PATCH,OPTIONS` |
 | [ingress.appscode.com/cors-allow-origin](/docs/guides/ingress/http/cors.md) | string | `*` |
 | [ingress.appscode.com/default-option](/docs/guides/ingress/configuration/default-options.md) | map | `{"http-server-close": "true", "dontlognull": "true"}` |
-| [ingress.appscode.com/default-timeout](/docs/guides/ingress/configuration/default-timeouts.md) | map | `{"connect": "50s", "server": "50s", "client": "50s", "client-fin": "50s", "tunnel": "50s"}` |
+| [ingress.appscode.com/default-timeout](/docs/guides/ingress/configuration/default-timeouts.md) | map | `{"connect": "5s", "server": "50s", "client": "50s", "client-fin": "50s", "tunnel": "50s"}` |
 | [ingress.appscode.com/auth-type](/docs/guides/ingress/security/basic-auth.md) | `basic` | |
 | [ingress.appscode.com/auth-realm](/docs/guides/ingress/security/basic-auth.md) | string | |
 | [ingress.appscode.com/auth-secret](/docs/guides/ingress/security/basic-auth.md) | string | |

--- a/docs/guides/ingress/configuration/body-size.md
+++ b/docs/guides/ingress/configuration/body-size.md
@@ -67,7 +67,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/config-volumes.md
+++ b/docs/guides/ingress/configuration/config-volumes.md
@@ -143,7 +143,7 @@ defaults
   # Timeout values
   timeout client 50s
   timeout client-fin 50s
-  timeout connect 50s
+  timeout connect 5s
   timeout server 50s
   timeout tunnel 50s
   # Configure error files

--- a/docs/guides/ingress/configuration/default-options.md
+++ b/docs/guides/ingress/configuration/default-options.md
@@ -74,7 +74,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/default-timeouts.md
+++ b/docs/guides/ingress/configuration/default-timeouts.md
@@ -89,7 +89,7 @@ backend test-server.default:80
 If any required timeouts is not provided timeouts will be populated with the following values.
 
 ```ini
-	timeout  connect         50s
+	timeout  connect         5s
 	timeout  client          50s
 	timeout  client-fin      50s
 	timeout  server          50s

--- a/docs/guides/ingress/configuration/http-2.md
+++ b/docs/guides/ingress/configuration/http-2.md
@@ -124,7 +124,7 @@ defaults
   # Timeout values
   timeout client 50s
   timeout client-fin 50s
-  timeout connect 50s
+  timeout connect 5s
   timeout server 50s
   timeout tunnel 50s
   # Configure error files
@@ -323,7 +323,7 @@ defaults
   # Timeout values
   timeout client 50s
   timeout client-fin 50s
-  timeout connect 50s
+  timeout connect 5s
   timeout server 50s
   timeout tunnel 50s
   # Configure error files

--- a/docs/guides/ingress/configuration/loadbalance-algorithm.md
+++ b/docs/guides/ingress/configuration/loadbalance-algorithm.md
@@ -69,7 +69,7 @@ defaults
   # Timeout values
   timeout client 50s
   timeout client-fin 50s
-  timeout connect 50s
+  timeout connect 5s
   timeout server 50s
   timeout tunnel 50s
   # Configure error files

--- a/docs/guides/ingress/configuration/max-connections.md
+++ b/docs/guides/ingress/configuration/max-connections.md
@@ -78,7 +78,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files
@@ -135,7 +135,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/node-port.md
+++ b/docs/guides/ingress/configuration/node-port.md
@@ -156,7 +156,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/rate-limit.md
+++ b/docs/guides/ingress/configuration/rate-limit.md
@@ -70,7 +70,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/rewrite-target.md
+++ b/docs/guides/ingress/configuration/rewrite-target.md
@@ -67,7 +67,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/ssl-passthrough.md
+++ b/docs/guides/ingress/configuration/ssl-passthrough.md
@@ -72,7 +72,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/ssl-redirect.md
+++ b/docs/guides/ingress/configuration/ssl-redirect.md
@@ -69,7 +69,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files
@@ -141,7 +141,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/configuration/whitelist.md
+++ b/docs/guides/ingress/configuration/whitelist.md
@@ -68,7 +68,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/http/hsts.md
+++ b/docs/guides/ingress/http/hsts.md
@@ -106,7 +106,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/docs/guides/ingress/tcp/tcp-sni.md
+++ b/docs/guides/ingress/tcp/tcp-sni.md
@@ -82,7 +82,7 @@ defaults
 	# Timeout values
 	timeout client 50s
 	timeout client-fin 50s
-	timeout connect 50s
+	timeout connect 5s
 	timeout server 50s
 	timeout tunnel 50s
 	# Configure error files

--- a/hack/example/haproxy_generated.cfg
+++ b/hack/example/haproxy_generated.cfg
@@ -23,7 +23,7 @@ defaults
     option dontlognull
 
     # Maximum time to wait for a connection attempt to a server to succeed.
-    timeout connect         50000
+    timeout connect         5000
 
     # Maximum inactivity time on the client side.
     # Applies when the client is expected to acknowledge or send data.


### PR DESCRIPTION
Default timeout values in haproxy configuration is now:
```
	timeout  connect         5s
	timeout  client          50s
	timeout  client-fin      50s
	timeout  server          50s
	timeout  tunnel          50s
```