### PR TITLE
Allow replica change when no hpa

### DIFF
--- a/chart/voyager/templates/cluster-role.yaml
+++ b/chart/voyager/templates/cluster-role.yaml
@@ -82,4 +82,9 @@ rules:
   - rolebindings
   - roles
   verbs: ["get", "create", "delete", "patch"]
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["get", "list"]
 {{ end }}

--- a/hack/deploy/rbac-list.yaml
+++ b/hack/deploy/rbac-list.yaml
@@ -92,6 +92,11 @@ rules:
   - rolebindings
   - roles
   verbs: ["get", "create", "delete", "patch"]
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/ingress/controller.go
+++ b/pkg/ingress/controller.go
@@ -180,3 +180,17 @@ func (c *controller) deletePods() error {
 	}
 	return core_util.RestartPods(c.KubeClient, c.Ingress.Namespace, &metav1.LabelSelector{MatchLabels: c.Ingress.OffshootSelector()})
 }
+
+func (c *controller) isHPAControlled() bool {
+	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		// in case an error happen when getting hpa, deciding to update replicas
+		return false
+	}
+	for _, hpa := range list.Items {
+		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ingress/hostport.go
+++ b/pkg/ingress/hostport.go
@@ -407,8 +407,8 @@ func (c *hostPortController) ensurePods() (kutil.VerbType, error) {
 			MatchLabels: c.Ingress.OffshootSelector(),
 		}
 
-		// assign number of replicas for initial creation only
-		if obj.Spec.Replicas == nil {
+		// assign number of replicas only when there's no controlling hpa
+		if obj.Spec.Replicas == nil || !c.isHPAControlled() {
 			obj.Spec.Replicas = types.Int32P(c.Ingress.Replicas())
 		}
 
@@ -560,4 +560,18 @@ func (c *hostPortController) ensurePods() (kutil.VerbType, error) {
 		return obj
 	})
 	return vt, err
+}
+
+func (c *hostPortController) isHPAControlled() bool {
+	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		// in case an error happen when getting hpa, deciding to update replicas
+		return false
+	}
+	for _, hpa := range list.Items {
+		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ingress/hostport.go
+++ b/pkg/ingress/hostport.go
@@ -561,17 +561,3 @@ func (c *hostPortController) ensurePods() (kutil.VerbType, error) {
 	})
 	return vt, err
 }
-
-func (c *hostPortController) isHPAControlled() bool {
-	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		// in case an error happen when getting hpa, deciding to update replicas
-		return false
-	}
-	for _, hpa := range list.Items {
-		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/ingress/internal.go
+++ b/pkg/ingress/internal.go
@@ -476,17 +476,3 @@ func (c *internalController) ensurePods() (kutil.VerbType, error) {
 	})
 	return vt, err
 }
-
-func (c *internalController) isHPAControlled() bool {
-	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		// in case an error happen when getting hpa, deciding to update replicas
-		return false
-	}
-	for _, hpa := range list.Items {
-		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/ingress/internal.go
+++ b/pkg/ingress/internal.go
@@ -325,8 +325,8 @@ func (c *internalController) ensurePods() (kutil.VerbType, error) {
 			MatchLabels: c.Ingress.OffshootSelector(),
 		}
 
-		// assign number of replicas for initial creation only
-		if obj.Spec.Replicas == nil {
+		// assign number of replicas only when there's no controlling hpa
+		if obj.Spec.Replicas == nil || !c.isHPAControlled() {
 			obj.Spec.Replicas = types.Int32P(c.Ingress.Replicas())
 		}
 
@@ -475,4 +475,18 @@ func (c *internalController) ensurePods() (kutil.VerbType, error) {
 		return obj
 	})
 	return vt, err
+}
+
+func (c *internalController) isHPAControlled() bool {
+	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		// in case an error happen when getting hpa, deciding to update replicas
+		return false
+	}
+	for _, hpa := range list.Items {
+		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ingress/loadbalancer.go
+++ b/pkg/ingress/loadbalancer.go
@@ -577,17 +577,3 @@ func ipnet(spec string) (string, bool) {
 	}
 	return ipnet.String(), true
 }
-
-func (c *loadBalancerController) isHPAControlled() bool {
-	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		// in case an error happen when getting hpa, deciding to update replicas
-		return false
-	}
-	for _, hpa := range list.Items {
-		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/ingress/nodeport.go
+++ b/pkg/ingress/nodeport.go
@@ -595,17 +595,3 @@ func (c *nodePortController) ensurePods() (kutil.VerbType, error) {
 	})
 	return vt, err
 }
-
-func (c *nodePortController) isHPAControlled() bool {
-	list, err := c.KubeClient.AutoscalingV1().HorizontalPodAutoscalers(c.Ingress.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		// in case an error happen when getting hpa, deciding to update replicas
-		return false
-	}
-	for _, hpa := range list.Items {
-		if hpa.Spec.ScaleTargetRef.Kind == c.Ingress.WorkloadKind() && hpa.Spec.ScaleTargetRef.Name == c.Ingress.OffshootName() {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
- Change in `ingress.appscode.com/replicas` will only take effect when there's no hpa controlling that ingress deployment