### PR TITLE
Fix broken helm chart: unexpected end definition in cluster-role.yaml

### DIFF
--- a/chart/voyager/templates/cluster-role.yaml
+++ b/chart/voyager/templates/cluster-role.yaml
@@ -86,4 +86,3 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs: ["get", "list"]
-{{ end }}


### PR DESCRIPTION
#1397 removed the `--rbac` flag from templates but for `cluster-role.yaml` `{{ end }}` was left in the template by mistake. This throws errors like mentioned in #1433 

This PR just removed the extraneous `{{ end }}` 