### PR TITLE
workload-kind support StatefulSet

### DIFF
--- a/apis/voyager/v1beta1/annotations.go
+++ b/apis/voyager/v1beta1/annotations.go
@@ -646,8 +646,8 @@ func getWorkload(m map[string]string, key string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if w != wpi.KindDeployment && w != wpi.KindDaemonSet {
-		return nil, errors.Errorf("%s must be either Deployment or DaemonSet, found %s", WorkloadKind, w)
+	if w != wpi.KindDeployment && w != wpi.KindDaemonSet && w != wpi.KindStatefulSet {
+		return nil, errors.Errorf("%s must be either Deployment or DaemonSet or StatefulSet, found %s", WorkloadKind, w)
 	}
 	return w, nil
 }

--- a/pkg/ingress/controller.go
+++ b/pkg/ingress/controller.go
@@ -129,6 +129,11 @@ func (c *controller) IsExists() bool {
 		if kerr.IsNotFound(err) {
 			return false
 		}
+	} else if wk == wpi.KindStatefulSet {
+		_, err := c.KubeClient.AppsV1().StatefulSets(c.Ingress.Namespace).Get(c.Ingress.OffshootName(), metav1.GetOptions{})
+		if kerr.IsNotFound(err) {
+			return false
+		}
 	} else if wk == wpi.KindDaemonSet {
 		_, err := c.KubeClient.AppsV1().DaemonSets(c.Ingress.Namespace).Get(c.Ingress.OffshootName(), metav1.GetOptions{})
 		if kerr.IsNotFound(err) {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -86,6 +86,7 @@ func (c *OperatorConfig) New() (*Operator, error) {
 	op.initIngressCRDWatcher()
 	op.initIngressWatcher()
 	op.initDeploymentWatcher()
+	op.initStatefulSetWatcher()
 	op.initDaemonSetWatcher()
 	op.initServiceWatcher()
 	op.initConfigMapWatcher()

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -74,6 +74,11 @@ type Operator struct {
 	dpInformer cache.SharedIndexInformer
 	dpLister   apps_listers.DeploymentLister
 
+	// StatefulSet
+	stsQueue    *queue.Worker
+	stsInformer cache.SharedIndexInformer
+	stsLister   apps_listers.StatefulSetLister
+
 	// DaemonSet
 	dmQueue    *queue.Worker
 	dmInformer cache.SharedIndexInformer

--- a/pkg/operator/statefulset.go
+++ b/pkg/operator/statefulset.go
@@ -1,0 +1,58 @@
+package operator
+
+import (
+	"github.com/appscode/go/log"
+	"github.com/golang/glog"
+	"k8s.io/client-go/tools/cache"
+	"kmodules.xyz/client-go/tools/queue"
+	wpi "kmodules.xyz/webhook-runtime/apis/workload/v1"
+)
+
+func (op *Operator) initStatefulSetWatcher() {
+	op.stsInformer = op.kubeInformerFactory.Apps().V1().StatefulSets().Informer()
+	op.stsQueue = queue.New("StatefulSet", op.MaxNumRequeues, op.NumThreads, op.reconcileStatefulSet)
+	op.stsInformer.AddEventHandler(queue.NewDeleteHandler(op.dpQueue.GetQueue()))
+	op.stsLister = op.kubeInformerFactory.Apps().V1().StatefulSets().Lister()
+}
+
+func (op *Operator) reconcileStatefulSet(key string) error {
+	_, exists, err := op.dpInformer.GetIndexer().GetByKey(key)
+	if err != nil {
+		glog.Errorf("Fetching object with key %s from store failed with %v", key, err)
+		return err
+	}
+	if !exists {
+		glog.Warningf("StatefulSet %s does not exist anymore\n", key)
+		if ns, name, err := cache.SplitMetaNamespaceKey(key); err != nil {
+			return err
+		} else {
+			return op.restoreStatefulSet(name, ns)
+		}
+	}
+	return nil
+}
+
+// requeue ingress if user deletes haproxy-statefulset
+func (op *Operator) restoreStatefulSet(name, ns string) error {
+	items, err := op.listIngresses()
+	if err != nil {
+		return err
+	}
+	for i := range items {
+		ing := &items[i]
+		if ing.DeletionTimestamp == nil &&
+			ing.ShouldHandleIngress(op.IngressClass) &&
+			ing.Namespace == ns &&
+			ing.WorkloadKind() == wpi.KindStatefulSet &&
+			ing.OffshootName() == name {
+			if key, err := cache.MetaNamespaceKeyFunc(ing); err != nil {
+				return err
+			} else {
+				op.getIngressQueue(ing.APISchema()).Add(key)
+				log.Infof("Add/Delete/Update of haproxy statefulset %s/%s, Ingress %s re-queued for update", ns, name, key)
+				break
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Now annotation `ingress.appscode.com/workload-kind` only support Deployment and DeamonSet, but sometimes need workload type is StatefulSet.

ingress use annotation`ingress.appscode.com/workload-kind: StatefulSet`, so the workload will be StatefulSet.