### PR TITLE
Never exit certificates renewal infinite loop

### DIFF
--- a/pkg/operator/certificate_crds.go
+++ b/pkg/operator/certificate_crds.go
@@ -170,7 +170,7 @@ func (op *Operator) CheckCertificates() {
 						eventer.EventReasonCertificateInvalid,
 						err.Error(),
 					)
-					return
+					continue
 				}
 			}
 
@@ -182,7 +182,7 @@ func (op *Operator) CheckCertificates() {
 					eventer.EventReasonCertificateInvalid,
 					err.Error(),
 				)
-				return
+				continue
 			}
 			if err := ctrl.Process(); err != nil {
 				op.recorder.Event(


### PR DESCRIPTION
The `CheckCertificates()` goroutine should run an infinite loop, but it can exit via `return` after certain errors.

Because nothing restarts the goroutine, certificates simply stop getting checked for expiry when errors happen! This explains why renewals sporadically stopped in #1303 and #1443. No way to restart the loop either, other than restarting the pod.

This problem is hard to trace because even though the causing error is recorded as a Kubernetes event, it gets logged at most once (because the loop exits right after) and events are removed after one hour by default.

I changed the relevant `return` statements into `continue`. This not only ensures the loop is infinite so certificate renewals are always retried later despite errors, but also continually logs errors that are not transient so they become obvious.