### PR TITLE
Bump cloud.google.com/go to get timeout fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appscode/voyager
 go 1.12
 
 require (
-	cloud.google.com/go v0.38.0
+	cloud.google.com/go v0.54.0
 	github.com/Azure/azure-sdk-for-go v32.5.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.2
 	github.com/Azure/go-autorest/autorest/adal v0.7.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# cloud.google.com/go v0.38.0 => cloud.google.com/go v0.38.0
+# cloud.google.com/go v0.54.0 => cloud.google.com/go v0.38.0
 cloud.google.com/go/compute/metadata
 # github.com/Azure/azure-sdk-for-go v32.5.0+incompatible => github.com/Azure/azure-sdk-for-go v32.5.0+incompatible
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute


### PR DESCRIPTION
The commit we're interested in is
googleapis/google-cloud-go@fbf2f51 ,
which disables an aggressive 2-second timeout for awaiting headers from
the compute metadata service.

When workload identity is enabled on a cluster, a different endpoint is
used under the hood for compute metadata, and this endpoint can often
take more than 2 seconds to return headers.