### PR TITLE
Add missing ingresses/status resource to operator ClusterRole

### DIFF
--- a/charts/voyager/templates/cluster-role.yaml
+++ b/charts/voyager/templates/cluster-role.yaml
@@ -43,6 +43,7 @@ rules:
   - extensions
   resources:
   - ingresses
+  - ingresses/status
   verbs: ["*"]
 - apiGroups: [""]
   resources:


### PR DESCRIPTION
The Voyager Operator ClusterRole template of the Helm chart misses the`ingresses/status` resource of the apiGroup `extensions`.

The PR should fix #1483.