### PR TITLE
Haproxy exporter image repository

### DIFF
--- a/charts/voyager/templates/deployment.yaml
+++ b/charts/voyager/templates/deployment.yaml
@@ -47,7 +47,9 @@ spec:
         - --operator-service={{ template "voyager.fullname" . }}
         - --docker-registry={{ .Values.haproxy.registry }}
         - --haproxy-image-tag={{ .Values.haproxy.tag }}
+        - --haproxy-image-repository={{ .Values.haproxy.repository }}
         - --exporter-image-tag={{ .Values.voyager.tag }}
+        - --exporter-image-repository={{ .Values.voyager.repository }}
         - --secure-port=8443
         - --audit-log-path=-
         - --tls-cert-file=/var/serving-cert/tls.crt

--- a/docs/reference/voyager_run.md
+++ b/docs/reference/voyager_run.md
@@ -75,7 +75,9 @@ voyager run [flags]
       --egress-selector-config-file string                      File with apiserver egress selector configuration.
       --enable-validating-webhook                               If true, enables validating webhooks for Voyager CRDs.
       --exporter-image-tag string                               Tag of Docker image containing Prometheus exporter (default "v12.0.0-rc.1")
+      --exporter-image-repository string                        Repository of Docker image containing Prometheus exporter (default "voyager")
       --haproxy-image-tag string                                Tag of Docker image containing HAProxy binary (default "1.9.6-v12.0.0-rc.1-alpine")
+      --haproxy-image-repository string                         Repository of Docker image containing HAProxy binary (default "haproxy")
       --haproxy.server-metric-fields string                     Comma-separated list of exported server metrics. See http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1 (default "2,3,4,5,6,7,8,9,13,14,15,16,17,18,21,24,33,35,38,39,40,41,42,43,44")
       --haproxy.timeout duration                                Timeout for trying to get stats from HAProxy. (default 5s)
   -h, --help                                                    help for run

--- a/pkg/cmds/server/options.go
+++ b/pkg/cmds/server/options.go
@@ -53,7 +53,9 @@ type OperatorOptions struct {
 	NumThreads                  int
 	DockerRegistry              string
 	HAProxyImageTag             string
+	HAProxyImageRepository      string
 	ExporterImageTag            string
+	ExporterImageRepository     string
 
 	customTemplates           string
 	haProxyServerMetricFields string
@@ -65,11 +67,11 @@ type OperatorOptions struct {
 }
 
 func (s OperatorOptions) HAProxyImage() string {
-	return fmt.Sprintf("%s/haproxy:%s", s.DockerRegistry, s.HAProxyImageTag)
+	return fmt.Sprintf("%s/%s:%s", s.DockerRegistry, s.HAProxyImageRepository, s.HAProxyImageTag)
 }
 
 func (s OperatorOptions) ExporterImage() string {
-	return fmt.Sprintf("%s/voyager:%s", s.DockerRegistry, s.ExporterImageTag)
+	return fmt.Sprintf("%s/%s:%s", s.DockerRegistry, s.ExporterImageRepository, s.ExporterImageTag)
 }
 
 func (s OperatorOptions) WatchNamespace() string {
@@ -81,14 +83,16 @@ func (s OperatorOptions) WatchNamespace() string {
 
 func NewOperatorOptions() *OperatorOptions {
 	return &OperatorOptions{
-		DockerRegistry:    "appscode",
-		HAProxyImageTag:   "1.9.6-v12.0.0-rc.1-alpine",
-		ExporterImageTag:  "v12.0.0-rc.1",
-		OperatorNamespace: meta.Namespace(),
-		OperatorService:   "voyager-operator",
-		ResyncPeriod:      10 * time.Minute,
-		MaxNumRequeues:    5,
-		NumThreads:        2,
+		DockerRegistry:          "appscode",
+		HAProxyImageTag:         "1.9.6-v12.0.0-rc.1-alpine",
+		ExporterImageTag:        "v12.0.0-rc.1",
+		HAProxyImageRepository:  "haproxy",
+		ExporterImageRepository: "voyager",
+		OperatorNamespace:       meta.Namespace(),
+		OperatorService:         "voyager-operator",
+		ResyncPeriod:            10 * time.Minute,
+		MaxNumRequeues:          5,
+		NumThreads:              2,
 		// ref: https://github.com/kubernetes/ingress-nginx/blob/e4d53786e771cc6bdd55f180674b79f5b692e552/pkg/ingress/controller/launch.go#L252-L259
 		// High enough QPS to fit all expected use cases. QPS=0 is not set here, because client code is overriding it.
 		QPS: 1e6,
@@ -115,7 +119,9 @@ func (s *OperatorOptions) AddGoFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(&s.DockerRegistry, "docker-registry", s.DockerRegistry, "Docker image registry for HAProxy and Prometheus exporter")
 	fs.StringVar(&s.HAProxyImageTag, "haproxy-image-tag", s.HAProxyImageTag, "Tag of Docker image containing HAProxy binary")
+	fs.StringVar(&s.HAProxyImageTag, "haproxy-image-repository", s.HAProxyImageRepository, "Repository of Docker image containing HAProxy binary")
 	fs.StringVar(&s.ExporterImageTag, "exporter-image-tag", s.ExporterImageTag, "Tag of Docker image containing Prometheus exporter")
+	fs.StringVar(&s.ExporterImageTag, "exporter-image-repository", s.ExporterImageRepository, "Repository of Docker image containing Prometheus exporter")
 
 	fs.StringVar(&s.OperatorService, "operator-service", s.OperatorService, "Name of service used to expose voyager operator")
 	fs.BoolVar(&s.RestrictToOperatorNamespace, "restrict-to-operator-namespace", s.RestrictToOperatorNamespace, "If true, voyager operator will only handle Kubernetes objects in its own namespace.")


### PR DESCRIPTION
These options actually appear in the chart, and allowing them to set means
users can use their own naming convention when it comes to repositories.

The chart change may not actually be backwards compatible. If users have this
option set currently, it will have no effect, and so if it's set to something
other than the default (haproxy and voyager respectively), then the functionality
will change.

Fixes #1449

This is my first contribution, so let me know if the PR can be adjusted in any way.